### PR TITLE
fix broken dpdk link

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ make-smaller-titles: true
                  <a href="https://github.com/netsys/NetBricks">NetBricks</a> is a <em>safe and fast</em> framework for
                  rapid development of network functions for use in <a
                     href="https://en.wikipedia.org/wiki/Network_function_virtualization">NFV</a> written using <a href="https://rust-lang.org/">Rust</a> and <a
-             href="https://dpdk.org/">DPDK</a>.  NetBricks aims to make it faster to <em>develop</em> new NFs, while
+             href="http://dpdk.org/">DPDK</a>.  NetBricks aims to make it faster to <em>develop</em> new NFs, while
          also providing faster mechanisms for safely chaining NFs. The code is still work in progress and is changing,
              but <a href="https://github.com/NetSys/NetBricks/pulls">Pull Requests</a> and suggestions are welcome.
                  </p>


### PR DESCRIPTION
dpdk.org is not currently available via https.