### PR TITLE
Move Context and change configuration

### DIFF
--- a/framework/src/common/errors.rs
+++ b/framework/src/common/errors.rs
@@ -1,5 +1,5 @@
 error_chain! {
-    errors {   
+    errors {
         FailedAllocation {
             description("Failed to allocate memory")
             display("Failed to allocate memory")
@@ -71,4 +71,3 @@ error_chain! {
         Io(::std::io::Error);
     }
 }
-

--- a/framework/src/interface/dpdk.rs
+++ b/framework/src/interface/dpdk.rs
@@ -12,13 +12,13 @@ fn init_system_wl_with_mempool(name: &str, core: i32, pci: &[String], pool_size:
     let mut whitelist: Vec<_> = pci_cstr.iter().map(|p| p.as_ptr()).collect();
     unsafe {
         let ret = zcsi::init_system_whitelisted(name_cstr.as_ptr(),
-                                                   name.len() as i32,
-                                                   core,
-                                                   whitelist.as_mut_ptr(),
-                                                   pci.len() as i32,
-                                                   pool_size,
-                                                   cache_size,
-                                                   METADATA_SLOTS);
+                                                name.len() as i32,
+                                                core,
+                                                whitelist.as_mut_ptr(),
+                                                pci.len() as i32,
+                                                pool_size,
+                                                cache_size,
+                                                METADATA_SLOTS);
         if ret != 0 {
             panic!("Could not initialize the system errno {}", ret)
         }
@@ -37,10 +37,10 @@ pub fn init_system_secondary(name: &str, core: i32) {
     let mut vdev_list = vec![];
     unsafe {
         let ret = zcsi::init_secondary(name_cstr.as_ptr(),
-                                          name.len() as i32,
-                                          core,
-                                          vdev_list.as_mut_ptr(),
-                                          0);
+                                       name.len() as i32,
+                                       core,
+                                       vdev_list.as_mut_ptr(),
+                                       0);
         if ret != 0 {
             panic!("Could not initialize secondary process errno {}", ret)
         }
@@ -80,16 +80,12 @@ fn set_numa_domain() {
             domain
         }
     };
-    NUMA_DOMAIN.with(|f| {
-        f.set(domain)
-    })
+    NUMA_DOMAIN.with(|f| f.set(domain))
 }
 
 /// Affinitize a pthread to a core and assign a DPDK thread ID.
 pub fn init_thread(tid: i32, core: i32) {
-    let numa = unsafe {
-        zcsi::init_thread(tid, core)
-    };
+    let numa = unsafe { zcsi::init_thread(tid, core) };
     NUMA_DOMAIN.with(|f| {
         f.set(numa);
     });
@@ -102,7 +98,5 @@ pub fn init_thread(tid: i32, core: i32) {
 
 #[inline]
 pub fn get_domain() -> i32 {
-    NUMA_DOMAIN.with(|f| {
-        f.get()
-    })
+    NUMA_DOMAIN.with(|f| f.get())
 }

--- a/framework/src/native/zcsi/mod.rs
+++ b/framework/src/native/zcsi/mod.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(feature = "dev", allow(module_inception))]
 mod zcsi;
 mod mbuf;
 pub use self::zcsi::*;

--- a/framework/src/native/zcsi/zcsi.rs
+++ b/framework/src/native/zcsi/zcsi.rs
@@ -20,16 +20,16 @@ extern "C" {
                           vdev_count: i32)
                           -> i32;
     pub fn init_pmd_port(port: i32,
-                     rxqs: i32,
-                     txqs: i32,
-                     rx_cores: *const i32,
-                     tx_cores: *const i32,
-                     nrxd: i32,
-                     ntxd: i32,
-                     loopback: i32,
-                     tso: i32,
-                     csumoffload: i32)
-                     -> i32;
+                         rxqs: i32,
+                         txqs: i32,
+                         rx_cores: *const i32,
+                         tx_cores: *const i32,
+                         nrxd: i32,
+                         ntxd: i32,
+                         loopback: i32,
+                         tso: i32,
+                         csumoffload: i32)
+                         -> i32;
     pub fn free_pmd_port(port: i32) -> i32;
     pub fn recv_pkts(port: i32, qid: i32, pkts: *mut *mut MBuf, len: i32) -> i32;
     pub fn send_pkts(port: i32, qid: i32, pkts: *mut *mut MBuf, len: i32) -> i32;

--- a/framework/src/operators/packet_batch.rs
+++ b/framework/src/operators/packet_batch.rs
@@ -36,10 +36,10 @@ impl PacketBatch {
     pub fn allocate_batch_with_size(&mut self, len: u16) -> Result<&mut Self> {
         let cnt = self.cnt;
         self.alloc_packet_batch(len, cnt).and_then(|_| Ok(self))
-        //match self.alloc_packet_batch(len, cnt) {
-            //Ok(_) => Ok(self),
-            //Err(_) => Err(ErrorKind::FailedAllocation.into),
-        //}
+        // match self.alloc_packet_batch(len, cnt) {
+        // Ok(_) => Ok(self),
+        // Err(_) => Err(ErrorKind::FailedAllocation.into),
+        // }
     }
 
     /// Allocate `cnt` mbufs. `len` sets the metadata field indicating how much of the mbuf should be considred when

--- a/framework/src/scheduler/context.rs
+++ b/framework/src/scheduler/context.rs
@@ -6,8 +6,9 @@ use interface::dpdk::{init_system, init_thread};
 use allocators::CacheAligned;
 use std::sync::Arc;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use scheduler::*;
-use super::NetbricksConfiguration;
+use config::NetbricksConfiguration;
 
 type AlignedPortQueue = CacheAligned<PortQueue>;
 #[derive(Default)]
@@ -68,6 +69,7 @@ impl NetBricksContext {
 pub fn initialize_system(configuration: &NetbricksConfiguration) -> Result<NetBricksContext> {
     init_system(configuration);
     let mut ctx: NetBricksContext = Default::default();
+    let mut cores: HashSet<_> = configuration.cores.iter().cloned().collect();
     for port in &configuration.ports {
         if ctx.ports.contains_key(&port.name) {
             println!("Port {} appears twice in specification", port.name);
@@ -99,12 +101,26 @@ pub fn initialize_system(configuration: &NetbricksConfiguration) -> Result<NetBr
                                                                      {:?}",
                                                                     rx_q,
                                                                     port.name,
-                                                                    e)).into())
+                                                                    e))
+                            .into())
                     }
                 }
             }
         }
     }
-    ctx.active_cores = ctx.rx_queues.keys().cloned().collect();
+    if configuration.strict {
+        let other_cores: HashSet<_> = ctx.rx_queues.keys().cloned().collect();
+        let core_diff: Vec<_> = other_cores.difference(&cores).map(|c| c.to_string()).collect();
+        if !core_diff.is_empty() {
+            let missing_str = core_diff.join(", ");
+            return Err(ErrorKind::ConfigurationError(format!("Strict configuration selected but core(s) {} appear in \
+                                                              port configuration but not in cores",
+                                                              missing_str))
+                .into());
+        }
+    } else {
+        cores.extend(ctx.rx_queues.keys());
+    };
+    ctx.active_cores = cores.into_iter().collect();
     Ok(ctx)
 }

--- a/framework/src/scheduler/mod.rs
+++ b/framework/src/scheduler/mod.rs
@@ -13,6 +13,9 @@ impl<F> Executable for F
     }
 }
 pub use self::scheduler::*;
+pub use self::context::*;
 
 #[cfg_attr(feature = "dev", allow(module_inception))]
 mod scheduler;
+
+mod context;

--- a/framework/src/scheduler/scheduler.rs
+++ b/framework/src/scheduler/scheduler.rs
@@ -32,8 +32,12 @@ impl Scheduler {
     }
 
     pub fn new_with_channel(channel: Receiver<SchedulerCommand>) -> Scheduler {
+        Scheduler::new_with_channel_and_capacity(channel, DEFAULT_Q_SIZE)
+    }
+
+    pub fn new_with_channel_and_capacity(channel: Receiver<SchedulerCommand>, capacity: usize) -> Scheduler {
         Scheduler {
-            run_q: Vec::with_capacity(DEFAULT_Q_SIZE),
+            run_q: Vec::with_capacity(capacity),
             next_task: 0,
             sched_channel: channel,
         }

--- a/test/delay-test/src/main.rs
+++ b/test/delay-test/src/main.rs
@@ -88,6 +88,7 @@ fn main() {
                 .unwrap()
                 .parse()
                 .expect("Could not parse master core"),
+            strict: true,
             ..configuration
         }
     } else {
@@ -118,7 +119,7 @@ fn main() {
 
         let cores_str = matches.opt_strs("c");
 
-        let cores: Vec<i32> = cores_str.iter()
+        let mut cores: Vec<i32> = cores_str.iter()
             .map(|n: &String| n.parse().ok().expect(&format!("Core cannot be parsed {}", n)))
             .collect();
 
@@ -133,7 +134,8 @@ fn main() {
             let cores = cores_for_port.get(*port).unwrap();
             ports.push(PortConfiguration::new_with_queues(*port, cores, cores))
         }
-        NetbricksConfiguration { ports: ports, ..configuration }
+        cores.dedup();
+        NetbricksConfiguration { cores: cores, ports: ports, ..configuration }
     } else {
         configuration
     };


### PR DESCRIPTION
This was mostly done so that (a) cores could run without serving any
ports and (b) so I could make other changes to the scheduler