### PR TITLE
IpHeader::flow: use bytes, not bits for slicing

### DIFF
--- a/framework/src/headers/ip.rs
+++ b/framework/src/headers/ip.rs
@@ -70,13 +70,13 @@ impl IpHeader {
         let protocol = self.protocol();
         let src_ip = self.src();
         let dst_ip = self.dst();
-        if (protocol == 6 || protocol == 17) && self.payload_size(0) >= 32 {
+        if (protocol == 6 || protocol == 17) && self.payload_size(0) >= 4 {
             unsafe {
                 let self_as_u8 = (self as *const IpHeader) as *const u8;
                 let port_as_u8 = self_as_u8.offset(self.offset() as isize);
-                let port_slice = slice::from_raw_parts(port_as_u8, 32);
-                let dst_port = BigEndian::read_u16(&port_slice[..16]);
-                let src_port = BigEndian::read_u16(&port_slice[16..]);
+                let port_slice = slice::from_raw_parts(port_as_u8, 4);
+                let dst_port = BigEndian::read_u16(&port_slice[..2]);
+                let src_port = BigEndian::read_u16(&port_slice[2..]);
                 Some(Flow {
                          src_ip: src_ip,
                          dst_ip: dst_ip,


### PR DESCRIPTION
along with 8f6db05, fixes issue #49.