### PR TITLE
reordered_buffer: fix panic during data overlap

### DIFF
--- a/framework/src/state/reordered_buffer/reordered_buffer.rs
+++ b/framework/src/state/reordered_buffer/reordered_buffer.rs
@@ -499,8 +499,7 @@ impl ReorderedBuffer {
             }
         } else if self.tail_seq >= seq {
             let offset = (self.tail_seq - seq) as usize;
-            let remaining = data.len() - offset;
-            if remaining > 0 {
+            if data.len() > offset {
                 let tail_seq = self.tail_seq;
                 self.out_of_order_insert(tail_seq, &data[offset..])
             } else {

--- a/framework/tests/ring_buffer.rs
+++ b/framework/tests/ring_buffer.rs
@@ -15,7 +15,7 @@ fn write_at_offset_test() {
     let mut output: Vec<_> = (0..input.len()).map(|_| 0).collect();
     rb.read_from_offset(4095, &mut output[..]);
     for idx in 0..input.len() {
-        assert!(input[idx] == output[idx]);
+        assert_eq!(input[idx], output[idx]);
     }
 }
 
@@ -24,11 +24,11 @@ fn read_write_tail_test() {
     let mut rb = RingBuffer::new(1).unwrap();
     let input: Vec<_> = (0..8192).map(|i| (i & 0xff) as u8).collect();
     let written = rb.write_at_tail(&input[..]);
-    assert!(written == 4095);
+    assert_eq!(written, 4095);
     let mut output: Vec<_> = (0..8192).map(|_| 0).collect();
     let read = rb.read_from_head(&mut output[..]);
-    assert!(read == written);
+    assert_eq!(read, written);
     for idx in 0..read {
-        assert!(input[idx] == output[idx]);
+        assert_eq!(input[idx], output[idx]);
     }
 }

--- a/framework/tests/tcp_window.rs
+++ b/framework/tests/tcp_window.rs
@@ -168,6 +168,14 @@ fn test_out_of_order_insertion() {
                "Read does not match expected, read: {}, expected: {}",
                read,
                format!("{}{}{}", data0, data1, data2));
+
+    let data3 = [0, 1, 2];
+    if let InsertionResult::Inserted { written, available } = ro.add_data(base_seq - 6, &data3) {
+        assert_eq!(written, 0);
+        assert_eq!(available, 0);
+    } else {
+        panic!("Writing data3 failed");
+    }
 }
 
 /// Test that things work fine once state is changed.

--- a/framework/tests/tcp_window.rs
+++ b/framework/tests/tcp_window.rs
@@ -7,39 +7,51 @@ use std::u32;
 /// Test rounding up to number of pages.
 #[test]
 fn round_pages_test() {
-    assert!(round_to_pages(1) == 4096,
-            "Rounding up 1 byte did not result in PAGE_SIZE");
-    assert!(round_to_pages(0) == 0,
-            "Rounding up 0 bytes did not result in 0");
-    assert!(round_to_pages(8) == 4096,
-            "Rounding up failure, expected 4096, got {}",
-            round_to_pages(8));
-    assert!(round_to_pages(512) == 4096,
-            "Rounding up failure, expected 4096, got {}",
-            round_to_pages(512));
-    assert!(round_to_pages(4096) == 4096,
-            "Rounding up exactly 1 page failed, expected 4096, got {}",
-            round_to_pages(4096));
-    assert!(round_to_pages(4097) == 8192,
-            "Rounding up > 1 page failed, expected 8192, got {}",
-            round_to_pages(4097));
+    assert_eq!(round_to_pages(1),
+               4096,
+               "Rounding up 1 byte did not result in PAGE_SIZE");
+    assert_eq!(round_to_pages(0),
+               0,
+               "Rounding up 0 bytes did not result in 0");
+    assert_eq!(round_to_pages(8),
+               4096,
+               "Rounding up failure, expected 4096, got {}",
+               round_to_pages(8));
+    assert_eq!(round_to_pages(512),
+               4096,
+               "Rounding up failure, expected 4096, got {}",
+               round_to_pages(512));
+    assert_eq!(round_to_pages(4096),
+               4096,
+               "Rounding up exactly 1 page failed, expected 4096, got {}",
+               round_to_pages(4096));
+    assert_eq!(round_to_pages(4097),
+               8192,
+               "Rounding up > 1 page failed, expected 8192, got {}",
+               round_to_pages(4097));
 }
 
 /// Test rounding up to power of 2.
 #[test]
 fn round_to_power_of_2_test() {
-    assert!(round_to_power_of_2(0) == 0,
-            "Rounding to power of 2 failed, expected 0");
-    assert!(round_to_power_of_2(1) == 1,
-            "Rounding to power of 2 failed, expected 1");
-    assert!(round_to_power_of_2(2) == 2,
-            "Rounding to power of 2 failed, expected 2");
-    assert!(round_to_power_of_2(3) == 4,
-            "Rounding to power of 2 failed, expected 4");
-    assert!(round_to_power_of_2(4) == 4,
-            "Rounding to power of 2 failed, expected 4");
-    assert!(round_to_power_of_2(5) == 8,
-            "Rounding to power of 2 failed, expected 8");
+    assert_eq!(round_to_power_of_2(0),
+               0,
+               "Rounding to power of 2 failed, expected 0");
+    assert_eq!(round_to_power_of_2(1),
+               1,
+               "Rounding to power of 2 failed, expected 1");
+    assert_eq!(round_to_power_of_2(2),
+               2,
+               "Rounding to power of 2 failed, expected 2");
+    assert_eq!(round_to_power_of_2(3),
+               4,
+               "Rounding to power of 2 failed, expected 4");
+    assert_eq!(round_to_power_of_2(4),
+               4,
+               "Rounding to power of 2 failed, expected 4");
+    assert_eq!(round_to_power_of_2(5),
+               8,
+               "Rounding to power of 2 failed, expected 8");
 }
 
 /// Test that creation proceeds without a hitch.
@@ -62,14 +74,16 @@ fn test_in_order_insertion() {
     let data0 = "food";
     let base_seq = 1232;
     if let InsertionResult::Inserted { written, available } = ro.seq(base_seq, data0.as_bytes()) {
-        assert!(written == data0.len(),
-                "When writing with seq, not all data was written expected {} got {}",
-                written,
-                data0.len());
-        assert!(available == data0.len(),
-                "When writing in-order, not all data is available. Expected {} got {}",
-                available,
-                data0.len());
+        assert_eq!(written,
+                   data0.len(),
+                   "When writing with seq, not all data was written expected {} got {}",
+                   written,
+                   data0.len());
+        assert_eq!(available,
+                   data0.len(),
+                   "When writing in-order, not all data is available. Expected {} got {}",
+                   available,
+                   data0.len());
     } else {
         panic!("Seq failed");
     }
@@ -77,11 +91,12 @@ fn test_in_order_insertion() {
     let data1 = ": hamburger";
     if let InsertionResult::Inserted { written, available } =
         ro.add_data(base_seq.wrapping_add(data0.len() as u32), data1.as_bytes()) {
-        assert!(written == data1.len());
-        assert!(available == data0.len() + data1.len(),
-                "Incorrect data available: Expected {} got {}",
-                data0.len() + data1.len(),
-                available);
+        assert_eq!(written, data1.len());
+        assert_eq!(available,
+                   data0.len() + data1.len(),
+                   "Incorrect data available: Expected {} got {}",
+                   data0.len() + data1.len(),
+                   available);
     } else {
         panic!("Writing data1 failed");
     }
@@ -89,15 +104,17 @@ fn test_in_order_insertion() {
     let read_buf_len = data0.len() + data1.len() + 1;
     let mut read_buffer: Vec<_> = (0..read_buf_len).map(|_| 0).collect();
     let read = ro.read_data(&mut read_buffer[..]);
-    assert!(read == data0.len() + data1.len(),
-            "Read less than expected, read: {}, expected: {}",
-            read,
-            data0.len() + data1.len());
+    assert_eq!(read,
+               data0.len() + data1.len(),
+               "Read less than expected, read: {}, expected: {}",
+               read,
+               data0.len() + data1.len());
     let read_str = str::from_utf8(&read_buffer[..read]).unwrap();
-    assert!(read_str == format!("{}{}", data0, data1),
-            "Read does not match expected, read: {}, expected: {}",
-            read_str,
-            format!("{}{}", data0, data1));
+    assert_eq!(read_str,
+               format!("{}{}", data0, data1),
+               "Read does not match expected, read: {}, expected: {}",
+               read_str,
+               format!("{}{}", data0, data1));
 }
 
 /// Test that out of order insertion works correctly.
@@ -107,8 +124,8 @@ fn test_out_of_order_insertion() {
     let data0 = "food";
     let base_seq = 1232;
     if let InsertionResult::Inserted { written, available } = ro.seq(base_seq, data0.as_bytes()) {
-        assert!(written == data0.len());
-        assert!(available == data0.len());
+        assert_eq!(written, data0.len());
+        assert_eq!(available, data0.len());
     } else {
         panic!("Seq failed");
     }
@@ -120,19 +137,20 @@ fn test_out_of_order_insertion() {
                         .wrapping_add(data0.len() as u32)
                         .wrapping_add(data1.len() as u32),
                     data2.as_bytes()) {
-        assert!(written == data2.len());
-        assert!(available == data0.len());
+        assert_eq!(written, data2.len());
+        assert_eq!(available, data0.len());
     } else {
         panic!("Writing data2 failed");
     }
 
     if let InsertionResult::Inserted { written, available } =
         ro.add_data(base_seq.wrapping_add(data0.len() as u32), data1.as_bytes()) {
-        assert!(written == data1.len(),
-                "Unexpected write, expected {} got {}",
-                data1.len(),
-                written);
-        assert!(available == data0.len() + data1.len() + data2.len());
+        assert_eq!(written,
+                   data1.len(),
+                   "Unexpected write, expected {} got {}",
+                   data1.len(),
+                   written);
+        assert_eq!(available, data0.len() + data1.len() + data2.len());
     } else {
         panic!("Writing data1 failed");
     }
@@ -140,14 +158,16 @@ fn test_out_of_order_insertion() {
     let read_buf_len = ro.available();
     let mut read_buffer: Vec<_> = (0..read_buf_len).map(|_| 0).collect();
     let read = ro.read_data(&mut read_buffer[..]);
-    assert!(read == read_buf_len, "Read less than what is available");
-    assert!(ro.available() == 0,
-            "Read everything but data is still available");
+    assert_eq!(read, read_buf_len, "Read less than what is available");
+    assert_eq!(ro.available(),
+               0,
+               "Read everything but data is still available");
     let read = str::from_utf8(&read_buffer[..read]).unwrap();
-    assert!(read == format!("{}{}{}", data0, data1, data2),
-            "Read does not match expected, read: {}, expected: {}",
-            read,
-            format!("{}{}{}", data0, data1, data2));
+    assert_eq!(read,
+               format!("{}{}{}", data0, data1, data2),
+               "Read does not match expected, read: {}, expected: {}",
+               read,
+               format!("{}{}{}", data0, data1, data2));
 }
 
 /// Test that things work fine once state is changed.
@@ -157,8 +177,8 @@ fn test_state_change() {
     let data0 = "food";
     let base_seq = 1232;
     if let InsertionResult::Inserted { written, available } = ro.seq(base_seq, data0.as_bytes()) {
-        assert!(written == data0.len());
-        assert!(available == data0.len());
+        assert_eq!(written, data0.len());
+        assert_eq!(available, data0.len());
     } else {
         panic!("Seq failed");
     }
@@ -170,24 +190,26 @@ fn test_state_change() {
         .wrapping_add(data0.len() as u32)
         .wrapping_add(data1.len() as u32);
     if let InsertionResult::Inserted { written, available } = ro.add_data(data2_seq, data2.as_bytes()) {
-        assert!(written == data2.len());
-        assert!(available == data0.len(),
-                "Incorrect data available, expected {} found {} (seq {}, base {})",
-                data0.len(),
-                available,
-                data2_seq,
-                base_seq);
+        assert_eq!(written, data2.len());
+        assert_eq!(available,
+                   data0.len(),
+                   "Incorrect data available, expected {} found {} (seq {}, base {})",
+                   data0.len(),
+                   available,
+                   data2_seq,
+                   base_seq);
     } else {
         panic!("Writing data2 failed");
     }
 
     if let InsertionResult::Inserted { written, available } =
         ro.add_data(base_seq.wrapping_add(data0.len() as u32), data1.as_bytes()) {
-        assert!(written == data1.len(),
-                "Unexpected write, expected {} got {}",
-                data1.len(),
-                written);
-        assert!(available == data0.len() + data1.len() + data2.len());
+        assert_eq!(written,
+                   data1.len(),
+                   "Unexpected write, expected {} got {}",
+                   data1.len(),
+                   written);
+        assert_eq!(available, data0.len() + data1.len() + data2.len());
     } else {
         panic!("Writing data1 failed");
     }
@@ -198,22 +220,25 @@ fn test_state_change() {
                         .wrapping_add(data1.len() as u32)
                         .wrapping_add(data2.len() as u32),
                     data3.as_bytes()) {
-        assert!(written == data3.len());
-        assert!(available == data0.len() + data1.len() + data2.len() + data3.len());
+        assert_eq!(written, data3.len());
+        assert_eq!(available,
+                   data0.len() + data1.len() + data2.len() + data3.len());
     } else {
         panic!("Writing data3 failed");
     }
     let read_buf_len = ro.available();
     let mut read_buffer: Vec<_> = (0..read_buf_len).map(|_| 0).collect();
     let read = ro.read_data(&mut read_buffer[..]);
-    assert!(read == read_buf_len, "Read less than what is available");
-    assert!(ro.available() == 0,
-            "Read everything but data is still available");
+    assert_eq!(read, read_buf_len, "Read less than what is available");
+    assert_eq!(ro.available(),
+               0,
+               "Read everything but data is still available");
     let read = str::from_utf8(&read_buffer[..read]).unwrap();
-    assert!(read == format!("{}{}{}{}", data0, data1, data2, data3),
-            "Read does not match expected, read: {}, expected: {}",
-            read,
-            format!("{}{}{}{}", data0, data1, data2, data3));
+    assert_eq!(read,
+               format!("{}{}{}{}", data0, data1, data2, data3),
+               "Read does not match expected, read: {}, expected: {}",
+               read,
+               format!("{}{}{}{}", data0, data1, data2, data3));
 }
 
 /// Test that things OOM correctly when out of memory.
@@ -227,7 +252,7 @@ fn test_oom() {
 
     let iters = (4096 / data0.len()) - 1;
     if let InsertionResult::Inserted { written, .. } = r0.seq(base_seq, data0.as_bytes()) {
-        assert!(written == data0.len());
+        assert_eq!(written, data0.len());
     } else {
         panic!("Could not write");
     }
@@ -235,15 +260,15 @@ fn test_oom() {
     for _ in 1..iters {
         seq = seq.wrapping_add(data0.len() as u32);
         if let InsertionResult::Inserted { written, .. } = r0.add_data(seq, data0.as_bytes()) {
-            assert!(written == data0.len());
+            assert_eq!(written, data0.len());
         } else {
             panic!("Could not write");
         }
     }
     seq = seq.wrapping_add(data0.len() as u32);
     if let InsertionResult::OutOfMemory { written, available } = r0.add_data(seq, data0.as_bytes()) {
-        assert!(written != data0.len());
-        assert!(available == 4096 - 1);
+        assert_ne!(written, data0.len());
+        assert_eq!(available, 4096 - 1);
     } else {
         panic!("No OOM?");
     }
@@ -260,7 +285,7 @@ fn test_reset() {
 
     let iters = (4096 / data0.len()) - 1;
     if let InsertionResult::Inserted { written, .. } = r0.seq(base_seq, data0.as_bytes()) {
-        assert!(written == data0.len());
+        assert_eq!(written, data0.len());
     } else {
         panic!("Could not write");
     }
@@ -268,7 +293,7 @@ fn test_reset() {
     for _ in 1..iters {
         seq = seq.wrapping_add(data0.len() as u32);
         if let InsertionResult::Inserted { written, .. } = r0.add_data(seq, data0.as_bytes()) {
-            assert!(written == data0.len());
+            assert_eq!(written, data0.len());
         } else {
             panic!("Could not write");
         }
@@ -276,8 +301,8 @@ fn test_reset() {
 
     seq = seq.wrapping_add(data0.len() as u32);
     if let InsertionResult::OutOfMemory { written, available } = r0.add_data(seq, data0.as_bytes()) {
-        assert!(written != data0.len());
-        assert!(available == 4096 - 1);
+        assert_ne!(written, data0.len());
+        assert_eq!(available, 4096 - 1);
     } else {
         panic!("No OOM?");
     }
@@ -287,7 +312,7 @@ fn test_reset() {
     let mut seq = base_seq;
 
     if let InsertionResult::Inserted { written, .. } = r0.seq(base_seq, data0.as_bytes()) {
-        assert!(written == data0.len());
+        assert_eq!(written, data0.len());
     } else {
         panic!("Could not write");
     }
@@ -295,7 +320,7 @@ fn test_reset() {
     for _ in 1..iters {
         seq = seq.wrapping_add(data0.len() as u32);
         if let InsertionResult::Inserted { written, .. } = r0.add_data(seq, data0.as_bytes()) {
-            assert!(written == data0.len());
+            assert_eq!(written, data0.len());
         } else {
             panic!("Could not write");
         }
@@ -303,8 +328,8 @@ fn test_reset() {
 
     seq = seq.wrapping_add(data0.len() as u32);
     if let InsertionResult::OutOfMemory { written, available } = r0.add_data(seq, data0.as_bytes()) {
-        assert!(written != data0.len());
-        assert!(available == 4096 - 1);
+        assert_ne!(written, data0.len());
+        assert_eq!(available, 4096 - 1);
     } else {
         panic!("No OOM?");
     }
@@ -321,7 +346,7 @@ fn test_read_after_write() {
     let data = "testtest";
 
     if let InsertionResult::Inserted { written, .. } = r0.seq(base_seq, data.as_bytes()) {
-        assert!(written == data.len(), "Could not write during seq");
+        assert_eq!(written, data.len(), "Could not write during seq");
         base_seq = base_seq.wrapping_add(written as u32);
     } else {
         panic!("Could not seq");
@@ -331,7 +356,7 @@ fn test_read_after_write() {
 
     for i in 0..iters {
         if let InsertionResult::Inserted { written, .. } = r0.add_data(base_seq, data.as_bytes()) {
-            assert!(written == data.len());
+            assert_eq!(written, data.len());
             base_seq = base_seq.wrapping_add(written as u32);
         } else {
             panic!("Could not write data, iter {} seq {}", i, base_seq);
@@ -341,8 +366,9 @@ fn test_read_after_write() {
 
         let read = r0.read_data(&mut read_buf[..]);
 
-        assert!(available_before_read == r0.available() + read,
-                "Available bytes not adjusted by the right amount");
+        assert_eq!(available_before_read,
+                   r0.available() + read,
+                   "Available bytes not adjusted by the right amount");
     }
 }
 
@@ -357,17 +383,18 @@ fn test_overlapping_write() {
     let data1 = " world";
 
     if let InsertionResult::Inserted { written, .. } = r0.seq(base_seq, data0.as_bytes()) {
-        assert!(written == data0.len());
+        assert_eq!(written, data0.len());
     } else {
         panic!("Could not write data");
     }
 
     if let InsertionResult::Inserted { written, .. } =
         r0.add_data(base_seq + ("hello".len() as u32), data1.as_bytes()) {
-        assert!(written == "rld".len(),
-                "Overlapping write returns inconsistent result, expected {} got {}",
-                "rld".len(),
-                written);
+        assert_eq!(written,
+                   "rld".len(),
+                   "Overlapping write returns inconsistent result, expected {} got {}",
+                   "rld".len(),
+                   written);
     } else {
         panic!("Could not write data");
     }
@@ -375,13 +402,14 @@ fn test_overlapping_write() {
     let mut read_buf: Vec<_> = (0..r0.available()).map(|_| 0).collect();
     let read = r0.read_data(&mut read_buf[..]);
     let read_str = str::from_utf8(&read_buf[..read]).unwrap();
-    assert!(read_str == "hello world",
-            "Read value {} expected {}",
-            read_str,
-            "hello world");
+    assert_eq!(read_str,
+               "hello world",
+               "Read value {} expected {}",
+               read_str,
+               "hello world");
 
     if let InsertionResult::Inserted { written, .. } = r0.add_data(base_seq, data0.as_bytes()) {
-        assert!(written == 0, "Wrote even though packet is from the past");
+        assert_eq!(written, 0, "Wrote even though packet is from the past");
     } else {
         panic!("Could not write data");
     }


### PR DESCRIPTION
`let remaining = data.len() - offset` causes an underflow panic in all cases of `data` overlap except the case when `data.len() == offset`.