### PR TITLE
build.sh print_examples called even when example given

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -367,7 +367,7 @@ case $TASK in
         ;;
     run)
         shift
-        if [ $# -le 1 ]; then
+        if [ $# -le 0 ]; then
             print_examples
         fi
         cmd=$1
@@ -384,7 +384,7 @@ case $TASK in
         ;;
     debug)
         shift
-        if [ $# -le 1 ]; then
+        if [ $# -le 0 ]; then
             print_examples
         fi
         cmd=$1


### PR DESCRIPTION
./build.sh run <test-name> is supposed to build and run a single
test.  Instead it outputs the list of available tests.

The arguments have already been shifted so the check should be
<= 0