### PR TITLE
tcp window creation_test fails, cannot alloc > 1024MB

### DIFF
--- a/framework/tests/tcp_window.rs
+++ b/framework/tests/tcp_window.rs
@@ -59,9 +59,9 @@ fn round_to_power_of_2_test() {
 fn creation_test() {
     let mut i = 32;
     while i <= 1073741824 {
-        let ro = ReorderedBuffer::new(i).unwrap();
+        let ro = ReorderedBuffer::new(i - 1).unwrap();
         drop(ro);
-        let ro = ReorderedBuffer::new(i + 1).unwrap();
+        let ro = ReorderedBuffer::new(i).unwrap();
         drop(ro);
         i *= 2;
     }


### PR DESCRIPTION
dpdk requires 1024MB Hugepages to run.  But when the host
has allocated exactly that amount, tcp_window.rs creation_test
fails as when i == 1073741824, ReorderedBuffer::new(i + 1) asks
for more bytes than we have in Hugepages.

Change the test to ask for i - 1 and then i.