### PR TITLE
test tcp window creation_test fails, cannot alloc > 1024MB

### DIFF
--- a/framework/tests/tcp_window.rs
+++ b/framework/tests/tcp_window.rs
@@ -58,10 +58,11 @@ fn round_to_power_of_2_test() {
 #[test]
 fn creation_test() {
     let mut i = 32;
-    while i <= 1073741824 {
+    while i <= 1073741824 / 2 {
+        // /2 so test passes on host with 1024MB Hugepages
         let ro = ReorderedBuffer::new(i).unwrap();
         drop(ro);
-        let ro = ReorderedBuffer::new(i + 1).unwrap();
+        let ro = ReorderedBuffer::new(i + 1).unwrap(); // alloc next power of 2
         drop(ro);
         i *= 2;
     }


### PR DESCRIPTION
dpdk requires 1024MB Hugepages to run. But when the host
has allocated exactly that amount, tcp_window.rs creation_test
fails as when i == 1073741824, ReorderedBuffer::new(i + 1) asks
for more bytes than we have in Hugepages.

Change so the max i is /2. new(i + 1) will still test an
allocation requiring all pages, since the pages are always a
power of 2.