### PR TITLE
refactor examples

### DIFF
--- a/framework/src/config/flag_reader.rs
+++ b/framework/src/config/flag_reader.rs
@@ -1,0 +1,130 @@
+extern crate getopts;
+use self::getopts::{Options, Matches};
+
+use super::{NetbricksConfiguration, PortConfiguration, read_configuration};
+use common::print_error;
+use std::collections::HashMap;
+
+use std::env;
+use std::process;
+
+/// Return a `getopts::Options` struct, preset so that it's ready to parse the
+/// configuration flags commonly used during Netbricks examples.
+pub fn basic_opts() -> Options {
+    let mut opts = Options::new();
+    opts.optflag("h", "help", "print this help menu");
+    opts.optflag("", "secondary", "run as a secondary process");
+    opts.optflag("", "primary", "run as a primary process");
+    opts.optopt("n", "name", "name to use for the current process", "name");
+    opts.optmulti("p", "port", "Port to use", "[type:]id");
+    opts.optmulti("c", "core", "Core to use", "core");
+    opts.optopt("m", "master", "Master core", "master");
+    opts.optopt("f", "configuration", "Configuration file", "path");
+
+    opts
+}
+
+/// Read the commonly used configuration flags parsed by `basic_opts()` into
+/// a `NetbricksConfiguration`. Some flags may cause side effects -- for example, the
+/// help flag will print usage information and then exit the process.
+pub fn read_matches(matches: &Matches, opts: &Options) -> NetbricksConfiguration {
+    if matches.opt_present("h") {
+        let program = env::args().next().unwrap();
+        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
+        process::exit(0)
+    }
+
+    let configuration = if matches.opt_present("f") {
+        let config_file = matches.opt_str("f").unwrap();
+        match read_configuration(&config_file[..]) {
+            Ok(cfg) => cfg,
+            Err(ref e) => {
+                print_error(e);
+                process::exit(1);
+            }
+        }
+    } else {
+        let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
+        NetbricksConfiguration::new_with_name(&name[..])
+    };
+
+    let configuration = if matches.opt_present("m") {
+        NetbricksConfiguration {
+            primary_core: matches
+                .opt_str("m")
+                .unwrap()
+                .parse()
+                .expect("Could not parse master core"),
+            strict: true,
+            ..configuration
+        }
+    } else {
+        configuration
+    };
+
+    let configuration = if matches.opt_present("secondary") {
+        NetbricksConfiguration {
+            secondary: true,
+            ..configuration
+        }
+    } else {
+        configuration
+    };
+
+    let configuration = if matches.opt_present("primary") {
+        NetbricksConfiguration {
+            secondary: false,
+            ..configuration
+        }
+    } else {
+        configuration
+    };
+
+    let configuration = if matches.opt_present("c") {
+
+        let cores_str = matches.opt_strs("c");
+
+        let mut cores: Vec<i32> = cores_str
+            .iter()
+            .map(|n: &String| {
+                     n.parse()
+                         .ok()
+                         .expect(&format!("Core cannot be parsed {}", n))
+                 })
+            .collect();
+
+
+        let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
+
+        let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
+
+        let mut ports = Vec::with_capacity(ports_to_activate.len());
+
+        for port in &ports_to_activate {
+            let cores = cores_for_port.get(*port).unwrap();
+            ports.push(PortConfiguration::new_with_queues(*port, cores, cores))
+        }
+        cores.dedup();
+        NetbricksConfiguration {
+            cores: cores,
+            ports: ports,
+            ..configuration
+        }
+    } else {
+        configuration
+    };
+
+    println!("Going to start with configuration {}", configuration);
+    configuration
+}
+
+fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
+    let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
+    for (port, core) in ports.iter().zip(cores.iter()) {
+        cores_for_port
+            .entry(port.clone())
+            .or_insert(vec![])
+            .push(*core)
+    }
+    cores_for_port
+}

--- a/framework/src/config/mod.rs
+++ b/framework/src/config/mod.rs
@@ -1,6 +1,8 @@
 pub use self::config_reader::*;
+pub use self::flag_reader::*;
 use std::fmt;
 mod config_reader;
+mod flag_reader;
 
 /// `NetBricks` control configuration. In theory all applications create one of these, either through the use of
 /// `read_configuration` or manually using args.

--- a/test/acl-fw/src/main.rs
+++ b/test/acl-fw/src/main.rs
@@ -12,11 +12,7 @@ use e2d2::interface::*;
 use e2d2::operators::*;
 use e2d2::scheduler::*;
 use e2d2::utils::Ipv4Prefix;
-use getopts::Options;
-use std::collections::HashMap;
 use std::env;
-use std::error::Error;
-use std::process;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -51,115 +47,13 @@ fn test<S: Scheduler + Sized>(ports: Vec<CacheAligned<PortQueue>>, sched: &mut S
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let program = args[0].clone();
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("", "secondary", "run as a secondary process");
-    opts.optflag("", "primary", "run as a primary process");
-    opts.optopt("n", "name", "name to use for the current process", "name");
-    opts.optmulti("p", "port", "Port to use", "[type:]id");
-    opts.optmulti("c", "core", "Core to use", "core");
-    opts.optopt("m", "master", "Master core", "master");
-    opts.optopt("f", "configuration", "Configuration file", "path");
+
+    let opts = basic_opts();
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
     };
-    if matches.opt_present("h") {
-        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
-        process::exit(0)
-    }
-
-    let configuration = if matches.opt_present("f") {
-        let config_file = matches.opt_str("f").unwrap();
-        match read_configuration(&config_file[..]) {
-            Ok(cfg) => cfg,
-            Err(e) => {
-                panic!("Could not parse configuration file {}\n {}",
-                       config_file,
-                       e.description())
-            }
-        }
-    } else {
-        let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
-        NetbricksConfiguration::new_with_name(&name[..])
-    };
-
-    let configuration = if matches.opt_present("m") {
-        NetbricksConfiguration {
-            primary_core: matches
-                .opt_str("m")
-                .unwrap()
-                .parse()
-                .expect("Could not parse master core"),
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    let configuration = if matches.opt_present("secondary") {
-        NetbricksConfiguration {
-            secondary: true,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    let configuration = if matches.opt_present("primary") {
-        NetbricksConfiguration {
-            secondary: false,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
-        let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
-        for (port, core) in ports.iter().zip(cores.iter()) {
-            cores_for_port
-                .entry(port.clone())
-                .or_insert(vec![])
-                .push(*core)
-        }
-        cores_for_port
-    }
-
-    let configuration = if matches.opt_present("c") {
-
-        let cores_str = matches.opt_strs("c");
-
-        let cores: Vec<i32> = cores_str
-            .iter()
-            .map(|n: &String| {
-                     n.parse()
-                         .ok()
-                         .expect(&format!("Core cannot be parsed {}", n))
-                 })
-            .collect();
-
-
-        let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
-
-        let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
-
-        let mut ports = Vec::with_capacity(ports_to_activate.len());
-
-        for port in &ports_to_activate {
-            let cores = cores_for_port.get(*port).unwrap();
-            ports.push(PortConfiguration::new_with_queues(*port, cores, cores))
-        }
-        NetbricksConfiguration {
-            ports: ports,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    println!("Going to start with configuration {}", configuration);
+    let configuration = read_matches(&matches, &opts);
 
     let mut config = initialize_system(&configuration).unwrap();
     config.start_schedulers();

--- a/test/chain-test/src/main.rs
+++ b/test/chain-test/src/main.rs
@@ -5,14 +5,12 @@ extern crate time;
 extern crate getopts;
 extern crate rand;
 use self::nf::*;
-use e2d2::allocators::*;
+use e2d2::config::{basic_opts, read_matches};
 use e2d2::interface::*;
-use e2d2::interface::dpdk::*;
 use e2d2::operators::*;
 use e2d2::scheduler::*;
-use getopts::Options;
-use std::collections::HashMap;
 use std::env;
+use std::fmt::Display;
 use std::process;
 use std::sync::Arc;
 use std::thread;
@@ -21,15 +19,14 @@ mod nf;
 
 const CONVERSION_FACTOR: f64 = 1000000000.;
 
-fn recv_thread(ports: Vec<CacheAligned<PortQueue>>, core: i32, chain_len: u32, chain_pos: u32) {
-    init_thread(core, core);
+fn test<T, S>(ports: Vec<T>, sched: &mut S, chain_len: u32, chain_pos: u32)
+    where T: PacketRx + PacketTx + Display + Clone + 'static,
+          S: Scheduler + Sized
+{
     println!("Receiving started");
     for port in &ports {
-        println!("Receiving port {} rxq {} txq {} on core {} len {} pos {}",
-                 port.port.mac_address(),
-                 port.rxq(),
-                 port.txq(),
-                 core,
+        println!("Receiving port {} on chain len {} pos {}",
+                 port,
                  chain_len,
                  chain_pos);
     }
@@ -39,36 +36,24 @@ fn recv_thread(ports: Vec<CacheAligned<PortQueue>>, core: i32, chain_len: u32, c
         .map(|port| chain(ReceiveBatch::new(port.clone()), chain_len, chain_pos).send(port.clone()))
         .collect();
     println!("Running {} pipelines", pipelines.len());
-    let mut sched = StandaloneScheduler::new();
     for pipeline in pipelines {
         sched.add_task(pipeline).unwrap();
     }
-    sched.execute_loop();
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    let program = args[0].clone();
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("", "secondary", "run as a secondary process");
-    opts.optopt("n", "name", "name to use for the current process", "name");
-    opts.optmulti("p", "port", "Port to use", "[type:]id");
-    opts.optmulti("c", "core", "Core to use", "core");
-    opts.optopt("m", "master", "Master core", "master");
+    let mut opts = basic_opts();
     opts.optopt("l", "chain", "Chain length", "length");
     opts.optopt("j",
                 "position",
                 "Chain position (when externally chained)",
                 "position");
+    let args: Vec<String> = env::args().collect();
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
     };
-    if matches.opt_present("h") {
-        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
-        process::exit(0)
-    }
+    let configuration = read_matches(&matches, &opts);
 
     let chain_len = matches
         .opt_str("l")
@@ -82,108 +67,54 @@ fn main() {
         .parse()
         .expect("Could not parse chain position");
 
-    let cores_str = matches.opt_strs("c");
-    let master_core = matches
-        .opt_str("m")
-        .unwrap_or_else(|| String::from("0"))
-        .parse()
-        .expect("Could not parse master core spec");
-    println!("Using master core {}", master_core);
-    let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
+    match initialize_system(&configuration) {
+        Ok(mut context) => {
+            context.start_schedulers();
+            context
+                .add_pipeline_to_run(Arc::new(move |p, s: &mut StandaloneScheduler| test(p, s, chain_len, chain_pos)));
+            context.execute();
 
-    let cores: Vec<i32> = cores_str
-        .iter()
-        .map(|n: &String| {
-                 n.parse()
-                     .ok()
-                     .expect(&format!("Core cannot be parsed {}", n))
-             })
-        .collect();
-
-
-    fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
-        let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
-        for (port, core) in ports.iter().zip(cores.iter()) {
-            cores_for_port
-                .entry(port.clone())
-                .or_insert(vec![])
-                .push(*core)
-        }
-        cores_for_port
-    }
-
-    let primary = !matches.opt_present("secondary");
-
-    let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
-
-    if primary {
-        init_system_wl(&name, master_core, &[]);
-    } else {
-        init_system_secondary(&name, master_core);
-    }
-
-    let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
-
-    let mut queues_by_core = HashMap::<i32, Vec<_>>::with_capacity(cores.len());
-    let mut ports = Vec::<Arc<PmdPort>>::with_capacity(ports_to_activate.len());
-    for port in &ports_to_activate {
-        let cores = cores_for_port.get(*port).unwrap();
-        let queues = cores.len() as i32;
-        let pmd_port = PmdPort::new_with_queues(*port, queues, queues, cores, cores)
-            .expect("Could not initialize port");
-        for (idx, core) in cores.iter().enumerate() {
-            let queue = idx as i32;
-            queues_by_core
-                .entry(*core)
-                .or_insert(vec![])
-                .push(PmdPort::new_queue_pair(&pmd_port, queue, queue).unwrap());
-        }
-        ports.push(pmd_port);
-    }
-
-
-    const _BATCH: usize = 1 << 10;
-    const _CHANNEL_SIZE: usize = 256;
-    let _thread: Vec<_> = queues_by_core
-        .iter()
-        .map(|(core, ports)| {
-                 let c = core.clone();
-                 let p: Vec<_> = ports.iter().map(|p| p.clone()).collect();
-                 std::thread::spawn(move || recv_thread(p, c, chain_len, chain_pos))
-             })
-        .collect();
-    let mut pkts_so_far = (0, 0);
-    let mut last_printed = 0.;
-    const MAX_PRINT_INTERVAL: f64 = 60.;
-    const PRINT_DELAY: f64 = 30.;
-    let sleep_delay = (PRINT_DELAY / 2.) as u64;
-    let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-    let sleep_time = Duration::from_millis(sleep_delay);
-    println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
-    loop {
-        thread::sleep(sleep_time); // Sleep for a bit
-        let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-        if now - start > PRINT_DELAY {
-            let mut rx = 0;
-            let mut tx = 0;
-            for port in &ports {
-                for q in 0..port.rxqs() {
-                    let (rp, tp) = port.stats(q);
-                    rx += rp;
-                    tx += tp;
+            let mut pkts_so_far = (0, 0);
+            let mut last_printed = 0.;
+            const MAX_PRINT_INTERVAL: f64 = 60.;
+            const PRINT_DELAY: f64 = 30.;
+            let sleep_delay = (PRINT_DELAY / 2.) as u64;
+            let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+            let sleep_time = Duration::from_millis(sleep_delay);
+            println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
+            loop {
+                thread::sleep(sleep_time); // Sleep for a bit
+                let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+                if now - start > PRINT_DELAY {
+                    let mut rx = 0;
+                    let mut tx = 0;
+                    for port in context.ports.values() {
+                        for q in 0..port.rxqs() {
+                            let (rp, tp) = port.stats(q);
+                            rx += rp;
+                            tx += tp;
+                        }
+                    }
+                    let pkts = (rx, tx);
+                    let rx_pkts = pkts.0 - pkts_so_far.0;
+                    if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
+                        println!("{:.2} OVERALL RX {:.2} TX {:.2}",
+                                 now - start,
+                                 rx_pkts as f64 / (now - start),
+                                 (pkts.1 - pkts_so_far.1) as f64 / (now - start));
+                        last_printed = now;
+                        start = now;
+                        pkts_so_far = pkts;
+                    }
                 }
             }
-            let pkts = (rx, tx);
-            let rx_pkts = pkts.0 - pkts_so_far.0;
-            if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
-                println!("{:.2} OVERALL RX {:.2} TX {:.2}",
-                         now - start,
-                         rx_pkts as f64 / (now - start),
-                         (pkts.1 - pkts_so_far.1) as f64 / (now - start));
-                last_printed = now;
-                start = now;
-                pkts_so_far = pkts;
+        }
+        Err(ref e) => {
+            println!("Error: {}", e);
+            if let Some(backtrace) = e.backtrace() {
+                println!("Backtrace: {:?}", backtrace);
             }
+            process::exit(1);
         }
     }
 }

--- a/test/delay-test/src/main.rs
+++ b/test/delay-test/src/main.rs
@@ -6,13 +6,10 @@ extern crate time;
 extern crate getopts;
 extern crate rand;
 use self::nf::*;
-use e2d2::common::*;
-use e2d2::config::*;
+use e2d2::config::{basic_opts, read_matches};
 use e2d2::interface::*;
 use e2d2::operators::*;
 use e2d2::scheduler::*;
-use getopts::Options;
-use std::collections::HashMap;
 use std::env;
 use std::fmt::Display;
 use std::process;
@@ -42,27 +39,16 @@ fn test<T, S>(ports: Vec<T>, sched: &mut S, delay_arg: u64)
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    let program = args[0].clone();
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("", "secondary", "run as a secondary process");
-    opts.optflag("", "primary", "run as a primary process");
-    opts.optopt("n", "name", "name to use for the current process", "name");
-    opts.optmulti("p", "port", "Port to use", "[type:]id");
-    opts.optmulti("c", "core", "Core to use", "core");
-    opts.optopt("m", "master", "Master core", "master");
+    let mut opts = basic_opts();
     opts.optopt("d", "delay", "Delay cycles", "cycles");
-    opts.optopt("f", "configuration", "Configuration file", "path");
     opts.optflag("t", "test", "Test mode do not use real ports");
+
+    let args: Vec<String> = env::args().collect();
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
     };
-    if matches.opt_present("h") {
-        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
-        process::exit(0)
-    }
+    let configuration = read_matches(&matches, &opts);
 
     let delay_arg = matches
         .opt_str("d")
@@ -70,102 +56,8 @@ fn main() {
         .parse()
         .expect("Could not parse delay");
 
-    let configuration = if matches.opt_present("f") {
-        let config_file = matches.opt_str("f").unwrap();
-        match read_configuration(&config_file[..]) {
-            Ok(cfg) => cfg,
-            Err(ref e) => {
-                print_error(e);
-                process::exit(1);
-            }
-        }
-    } else {
-        let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
-        NetbricksConfiguration::new_with_name(&name[..])
-    };
-
-    let configuration = if matches.opt_present("m") {
-        NetbricksConfiguration {
-            primary_core: matches
-                .opt_str("m")
-                .unwrap()
-                .parse()
-                .expect("Could not parse master core"),
-            strict: true,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    let configuration = if matches.opt_present("secondary") {
-        NetbricksConfiguration {
-            secondary: true,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    let configuration = if matches.opt_present("primary") {
-        NetbricksConfiguration {
-            secondary: false,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
     let phy_ports = !matches.opt_present("test");
 
-    fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
-        let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
-        for (port, core) in ports.iter().zip(cores.iter()) {
-            cores_for_port
-                .entry(port.clone())
-                .or_insert(vec![])
-                .push(*core)
-        }
-        cores_for_port
-    }
-
-    let configuration = if matches.opt_present("c") {
-
-        let cores_str = matches.opt_strs("c");
-
-        let mut cores: Vec<i32> = cores_str
-            .iter()
-            .map(|n: &String| {
-                     n.parse()
-                         .ok()
-                         .expect(&format!("Core cannot be parsed {}", n))
-                 })
-            .collect();
-
-
-        let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
-
-        let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
-
-        let mut ports = Vec::with_capacity(ports_to_activate.len());
-
-        for port in &ports_to_activate {
-            let cores = cores_for_port.get(*port).unwrap();
-            ports.push(PortConfiguration::new_with_queues(*port, cores, cores))
-        }
-        cores.dedup();
-        NetbricksConfiguration {
-            cores: cores,
-            ports: ports,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    println!("Going to start with configuration {}", configuration);
-
-    // let mut config = initialize_system(&configuration)
     match initialize_system(&configuration) {
         Ok(mut context) => {
             context.start_schedulers();

--- a/test/lpm/src/main.rs
+++ b/test/lpm/src/main.rs
@@ -5,13 +5,10 @@ extern crate time;
 extern crate getopts;
 extern crate rand;
 use self::nf::*;
-use e2d2::common::*;
 use e2d2::config::*;
 use e2d2::interface::*;
 use e2d2::operators::*;
 use e2d2::scheduler::*;
-use getopts::Options;
-use std::collections::HashMap;
 use std::env;
 use std::fmt::Display;
 use std::process;
@@ -42,124 +39,16 @@ fn test<T, S>(ports: Vec<T>, sched: &mut S)
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    let program = args[0].clone();
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("", "secondary", "run as a secondary process");
-    opts.optflag("", "primary", "run as a primary process");
-    opts.optopt("n", "name", "name to use for the current process", "name");
-    opts.optmulti("p", "port", "Port to use", "[type:]id");
-    opts.optmulti("c", "core", "Core to use", "core");
-    opts.optopt("m", "master", "Master core", "master");
-    opts.optopt("f", "configuration", "Configuration file", "path");
+    let mut opts = basic_opts();
     opts.optflag("t", "test", "Test mode do not use real ports");
+
+    let args: Vec<String> = env::args().collect();
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
     };
-    if matches.opt_present("h") {
-        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
-        process::exit(0)
-    }
-
-    let configuration = if matches.opt_present("f") {
-        let config_file = matches.opt_str("f").unwrap();
-        match read_configuration(&config_file[..]) {
-            Ok(cfg) => cfg,
-            Err(ref e) => {
-                print_error(e);
-                process::exit(1);
-            }
-        }
-    } else {
-        let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
-        NetbricksConfiguration::new_with_name(&name[..])
-    };
-
-
-    let configuration = if matches.opt_present("m") {
-        NetbricksConfiguration {
-            primary_core: matches
-                .opt_str("m")
-                .unwrap()
-                .parse()
-                .expect("Could not parse master core"),
-            strict: true,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-
-    let configuration = if matches.opt_present("secondary") {
-        NetbricksConfiguration {
-            secondary: true,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    let configuration = if matches.opt_present("primary") {
-        NetbricksConfiguration {
-            secondary: false,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
+    let configuration = read_matches(&matches, &opts);
     let phy_ports = !matches.opt_present("test");
-
-    fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
-        let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
-        for (port, core) in ports.iter().zip(cores.iter()) {
-            cores_for_port
-                .entry(port.clone())
-                .or_insert(vec![])
-                .push(*core)
-        }
-        cores_for_port
-    }
-
-
-    let configuration = if matches.opt_present("c") {
-
-        let cores_str = matches.opt_strs("c");
-
-        let mut cores: Vec<i32> = cores_str
-            .iter()
-            .map(|n: &String| {
-                     n.parse()
-                         .ok()
-                         .expect(&format!("Core cannot be parsed {}", n))
-                 })
-            .collect();
-
-
-        let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
-
-        let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
-
-        let mut ports = Vec::with_capacity(ports_to_activate.len());
-
-        for port in &ports_to_activate {
-            let cores = cores_for_port.get(*port).unwrap();
-            ports.push(PortConfiguration::new_with_queues(*port, cores, cores))
-        }
-        cores.dedup();
-        NetbricksConfiguration {
-            cores: cores,
-            ports: ports,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    println!("Going to start with configuration {}", configuration);
 
     match initialize_system(&configuration) {
         Ok(mut context) => {

--- a/test/maglev/src/main.rs
+++ b/test/maglev/src/main.rs
@@ -6,14 +6,12 @@ extern crate getopts;
 extern crate rand;
 extern crate twox_hash;
 use self::nf::*;
-use e2d2::allocators::CacheAligned;
+use e2d2::config::{basic_opts, read_matches};
 use e2d2::interface::*;
-use e2d2::interface::dpdk::*;
 use e2d2::operators::*;
 use e2d2::scheduler::*;
-use getopts::Options;
-use std::collections::HashMap;
 use std::env;
+use std::fmt::Display;
 use std::process;
 use std::sync::Arc;
 use std::thread;
@@ -22,152 +20,81 @@ mod nf;
 
 const CONVERSION_FACTOR: f64 = 1000000000.;
 
-fn recv_thread(ports: Vec<CacheAligned<PortQueue>>, core: i32) {
-    init_thread(core, core);
-    let mut sched = StandaloneScheduler::new();
+fn test<T, S>(ports: Vec<T>, sched: &mut S)
+    where T: PacketRx + PacketTx + Display + Clone + 'static,
+          S: Scheduler + Sized
+{
     println!("Receiving started");
-    for port in &ports {
-        println!("Receiving port {} rxq {} txq {} on core {}",
-                 port.port.mac_address(),
-                 port.rxq(),
-                 port.txq(),
-                 core);
-    }
 
     let pipelines: Vec<_> = ports
         .iter()
         .map(|port| {
                  maglev(ReceiveBatch::new(port.clone()),
-                        &mut sched,
+                        sched,
                         &vec!["Larry", "Curly", "Moe"])
                          .send(port.clone())
              })
         .collect();
     println!("Running {} pipelines", pipelines.len());
     sched.add_task(merge(pipelines)).unwrap();
-    sched.execute_loop();
 }
 
 fn main() {
+    let opts = basic_opts();
     let args: Vec<String> = env::args().collect();
-    let program = args[0].clone();
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("", "secondary", "run as a secondary process");
-    opts.optopt("n", "name", "name to use for the current process", "name");
-    opts.optmulti("p", "port", "Port to use", "[type:]id");
-    opts.optmulti("c", "core", "Core to use", "core");
-    opts.optopt("m", "master", "Master core", "master");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
     };
-    if matches.opt_present("h") {
-        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
-        process::exit(0)
-    }
+    let configuration = read_matches(&matches, &opts);
 
-    let cores_str = matches.opt_strs("c");
-    let master_core = matches
-        .opt_str("m")
-        .unwrap_or_else(|| String::from("0"))
-        .parse()
-        .expect("Could not parse master core spec");
-    println!("Using master core {}", master_core);
-    let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
+    match initialize_system(&configuration) {
+        Ok(mut context) => {
+            context.start_schedulers();
+            context.add_pipeline_to_run(Arc::new(move |p, s: &mut StandaloneScheduler| test(p, s)));
+            context.execute();
 
-    let cores: Vec<i32> = cores_str
-        .iter()
-        .map(|n: &String| {
-                 n.parse()
-                     .ok()
-                     .expect(&format!("Core cannot be parsed {}", n))
-             })
-        .collect();
-
-
-    fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
-        let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
-        for (port, core) in ports.iter().zip(cores.iter()) {
-            cores_for_port
-                .entry(port.clone())
-                .or_insert(vec![])
-                .push(*core)
-        }
-        cores_for_port
-    }
-
-    let primary = !matches.opt_present("secondary");
-
-    let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
-
-    if primary {
-        init_system_wl(&name, master_core, &[]);
-    } else {
-        init_system_secondary(&name, master_core);
-    }
-
-    let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
-
-    let mut queues_by_core = HashMap::<i32, Vec<_>>::with_capacity(cores.len());
-    let mut ports = Vec::<Arc<PmdPort>>::with_capacity(ports_to_activate.len());
-    for port in &ports_to_activate {
-        let cores = cores_for_port.get(*port).unwrap();
-        let queues = cores.len() as i32;
-        let pmd_port = PmdPort::new_with_queues(*port, queues, queues, cores, cores)
-            .expect("Could not initialize port");
-        for (idx, core) in cores.iter().enumerate() {
-            let queue = idx as i32;
-            queues_by_core
-                .entry(*core)
-                .or_insert(vec![])
-                .push(PmdPort::new_queue_pair(&pmd_port, queue, queue).unwrap());
-        }
-        ports.push(pmd_port);
-    }
-
-    const _BATCH: usize = 1 << 10;
-    const _CHANNEL_SIZE: usize = 256;
-    let _thread: Vec<_> = queues_by_core
-        .iter()
-        .map(|(core, ports)| {
-                 let c = core.clone();
-                 let p: Vec<_> = ports.iter().map(|p| p.clone()).collect();
-                 std::thread::spawn(move || recv_thread(p, c))
-             })
-        .collect();
-    let mut pkts_so_far = (0, 0);
-    let mut last_printed = 0.;
-    const MAX_PRINT_INTERVAL: f64 = 120.;
-    const PRINT_DELAY: f64 = 60.;
-    let sleep_delay = (PRINT_DELAY / 2.) as u64;
-    let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-    let sleep_time = Duration::from_millis(sleep_delay);
-    println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
-    loop {
-        thread::sleep(sleep_time); // Sleep for a bit
-        let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-        if now - start > PRINT_DELAY {
-            let mut rx = 0;
-            let mut tx = 0;
-            for port in &ports {
-                for q in 0..port.rxqs() {
-                    let (rp, tp) = port.stats(q);
-                    rx += rp;
-                    tx += tp;
+            let mut pkts_so_far = (0, 0);
+            let mut last_printed = 0.;
+            const MAX_PRINT_INTERVAL: f64 = 120.;
+            const PRINT_DELAY: f64 = 60.;
+            let sleep_delay = (PRINT_DELAY / 2.) as u64;
+            let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+            let sleep_time = Duration::from_millis(sleep_delay);
+            println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
+            loop {
+                thread::sleep(sleep_time); // Sleep for a bit
+                let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+                if now - start > PRINT_DELAY {
+                    let mut rx = 0;
+                    let mut tx = 0;
+                    for port in context.ports.values() {
+                        for q in 0..port.rxqs() {
+                            let (rp, tp) = port.stats(q);
+                            rx += rp;
+                            tx += tp;
+                        }
+                    }
+                    let pkts = (rx, tx);
+                    let rx_pkts = pkts.0 - pkts_so_far.0;
+                    if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
+                        println!("{:.2} OVERALL RX {:.2} TX {:.2}",
+                                 now - start,
+                                 rx_pkts as f64 / (now - start),
+                                 (pkts.1 - pkts_so_far.1) as f64 / (now - start));
+                        last_printed = now;
+                        start = now;
+                        pkts_so_far = pkts;
+                    }
                 }
             }
-            let pkts = (rx, tx);
-            let rx_pkts = pkts.0 - pkts_so_far.0;
-            if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
-                println!("{:.2} OVERALL RX {:.2} TX {:.2}",
-                         now - start,
-                         rx_pkts as f64 / (now - start),
-                         (pkts.1 - pkts_so_far.1) as f64 / (now - start));
-                last_printed = now;
-                start = now;
-                pkts_so_far = pkts;
+        }
+        Err(ref e) => {
+            println!("Error: {}", e);
+            if let Some(backtrace) = e.backtrace() {
+                println!("Backtrace: {:?}", backtrace);
             }
+            process::exit(1);
         }
     }
 }

--- a/test/nat/src/main.rs
+++ b/test/nat/src/main.rs
@@ -5,14 +5,12 @@ extern crate time;
 extern crate getopts;
 extern crate rand;
 use self::nf::*;
-use e2d2::allocators::CacheAligned;
+use e2d2::config::{basic_opts, read_matches};
 use e2d2::interface::*;
-use e2d2::interface::dpdk::*;
 use e2d2::operators::*;
 use e2d2::scheduler::*;
-use getopts::Options;
-use std::collections::HashMap;
 use std::env;
+use std::fmt::Display;
 use std::net::Ipv4Addr;
 use std::process;
 use std::sync::Arc;
@@ -22,23 +20,17 @@ mod nf;
 
 const CONVERSION_FACTOR: f64 = 1000000000.;
 
-fn recv_thread(ports: Vec<CacheAligned<PortQueue>>, core: i32) {
-    init_thread(core, core);
-    let mut sched = StandaloneScheduler::new();
+fn test<T, S>(ports: Vec<T>, sched: &mut S)
+    where T: PacketRx + PacketTx + Display + Clone + 'static,
+          S: Scheduler + Sized
+{
     println!("Receiving started");
-    for port in &ports {
-        println!("Receiving port {} rxq {} txq {} on core {}",
-                 port.port.mac_address(),
-                 port.rxq(),
-                 port.txq(),
-                 core);
-    }
 
     let mut pipelines: Vec<_> = ports
         .iter()
         .map(|port| {
                  nat(ReceiveBatch::new(port.clone()),
-                     &mut sched,
+                     sched,
                      &Ipv4Addr::new(10, 0, 0, 1))
                          .send(port.clone())
              })
@@ -49,130 +41,56 @@ fn recv_thread(ports: Vec<CacheAligned<PortQueue>>, core: i32) {
     } else {
         sched.add_task(pipelines.pop().unwrap()).unwrap()
     };
-    sched.execute_loop();
 }
 
 fn main() {
+    let opts = basic_opts();
+
     let args: Vec<String> = env::args().collect();
-    let program = args[0].clone();
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("", "secondary", "run as a secondary process");
-    opts.optopt("n", "name", "name to use for the current process", "name");
-    opts.optmulti("p", "port", "Port to use", "[type:]id");
-    opts.optmulti("c", "core", "Core to use", "core");
-    opts.optopt("m", "master", "Master core", "master");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
     };
-    if matches.opt_present("h") {
-        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
-        process::exit(0)
-    }
+    let configuration = read_matches(&matches, &opts);
 
-    let cores_str = matches.opt_strs("c");
-    let master_core = matches
-        .opt_str("m")
-        .unwrap_or_else(|| String::from("0"))
-        .parse()
-        .expect("Could not parse master core spec");
-    println!("Using master core {}", master_core);
-    let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
+    match initialize_system(&configuration) {
+        Ok(mut context) => {
+            context.start_schedulers();
+            context.add_pipeline_to_run(Arc::new(move |p, s: &mut StandaloneScheduler| test(p, s)));
+            context.execute();
 
-    let cores: Vec<i32> = cores_str
-        .iter()
-        .map(|n: &String| {
-                 n.parse()
-                     .ok()
-                     .expect(&format!("Core cannot be parsed {}", n))
-             })
-        .collect();
-
-
-    fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
-        let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
-        for (port, core) in ports.iter().zip(cores.iter()) {
-            cores_for_port
-                .entry(port.clone())
-                .or_insert(vec![])
-                .push(*core)
-        }
-        cores_for_port
-    }
-
-    let primary = !matches.opt_present("secondary");
-
-    let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
-
-    if primary {
-        init_system_wl(&name, master_core, &[]);
-    } else {
-        init_system_secondary(&name, master_core);
-    }
-
-    let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
-
-    let mut queues_by_core = HashMap::<i32, Vec<_>>::with_capacity(cores.len());
-    let mut ports = Vec::<Arc<PmdPort>>::with_capacity(ports_to_activate.len());
-    for port in &ports_to_activate {
-        let cores = cores_for_port.get(*port).unwrap();
-        let queues = cores.len() as i32;
-        let pmd_port = PmdPort::new_with_queues(*port, queues, queues, cores, cores)
-            .expect("Could not initialize port");
-        for (idx, core) in cores.iter().enumerate() {
-            let queue = idx as i32;
-            queues_by_core
-                .entry(*core)
-                .or_insert(vec![])
-                .push(PmdPort::new_queue_pair(&pmd_port, queue, queue).unwrap());
-        }
-        ports.push(pmd_port);
-    }
-
-
-    const _BATCH: usize = 1 << 10;
-    const _CHANNEL_SIZE: usize = 256;
-    let _thread: Vec<_> = queues_by_core
-        .iter()
-        .map(|(core, ports)| {
-                 let c = core.clone();
-                 let p: Vec<_> = ports.iter().map(|p| p.clone()).collect();
-                 std::thread::spawn(move || recv_thread(p, c))
-             })
-        .collect();
-    let mut pkts_so_far = (0, 0);
-    let mut last_printed = 0.;
-    const MAX_PRINT_INTERVAL: f64 = 1.0;
-    const PRINT_DELAY: f64 = 0.5;
-    let sleep_delay = (PRINT_DELAY / 2.) as u64;
-    let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-    let sleep_time = Duration::from_millis(sleep_delay);
-    println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
-    loop {
-        thread::sleep(sleep_time); // Sleep for a bit
-        let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-        if now - start > PRINT_DELAY {
-            let mut rx = 0;
-            let mut tx = 0;
-            for port in &ports {
-                for q in 0..port.rxqs() {
-                    let (rp, tp) = port.stats(q);
-                    rx += rp;
-                    tx += tp;
+            let mut pkts_so_far = (0, 0);
+            let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+            let sleep_time = Duration::from_millis(500);
+            loop {
+                thread::sleep(sleep_time); // Sleep for a bit
+                let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+                if now - start > 1.0 {
+                    let mut rx = 0;
+                    let mut tx = 0;
+                    for port in context.ports.values() {
+                        for q in 0..port.rxqs() {
+                            let (rp, tp) = port.stats(q);
+                            rx += rp;
+                            tx += tp;
+                        }
+                    }
+                    let pkts = (rx, tx);
+                    println!("{:.2} OVERALL RX {:.2} TX {:.2}",
+                             now - start,
+                             (pkts.0 - pkts_so_far.0) as f64 / (now - start),
+                             (pkts.1 - pkts_so_far.1) as f64 / (now - start));
+                    start = now;
+                    pkts_so_far = pkts;
                 }
             }
-            let pkts = (rx, tx);
-            let rx_pkts = pkts.0 - pkts_so_far.0;
-            if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
-                println!("{:.2} OVERALL RX {:.2} TX {:.2}",
-                         now - start,
-                         rx_pkts as f64 / (now - start),
-                         (pkts.1 - pkts_so_far.1) as f64 / (now - start));
-                last_printed = now;
-                start = now;
-                pkts_so_far = pkts;
+        }
+        Err(ref e) => {
+            println!("Error: {}", e);
+            if let Some(backtrace) = e.backtrace() {
+                println!("Backtrace: {:?}", backtrace);
             }
+            process::exit(1);
         }
     }
 }

--- a/test/packet_generation/src/main.rs
+++ b/test/packet_generation/src/main.rs
@@ -5,17 +5,13 @@ extern crate fnv;
 extern crate time;
 extern crate getopts;
 extern crate rand;
-use e2d2::allocators::CacheAligned;
-use e2d2::headers::*;
+use e2d2::config::{basic_opts, read_matches};
 use e2d2::interface::*;
-use e2d2::interface::dpdk::*;
 use e2d2::operators::*;
 use e2d2::queues::*;
 use e2d2::scheduler::*;
-use getopts::Options;
-use std::collections::HashMap;
-use std::convert::From;
 use std::env;
+use std::fmt::Display;
 use std::process;
 use std::sync::Arc;
 use std::thread;
@@ -25,152 +21,80 @@ use self::nf::*;
 
 const CONVERSION_FACTOR: f64 = 1000000000.;
 
-fn recv_thread(ports: Vec<CacheAligned<PortQueue>>, core: i32) {
-    init_thread(core, core);
+fn test<T, S>(ports: Vec<T>, sched: &mut S)
+    where T: PacketRx + PacketTx + Display + Clone + 'static,
+          S: Scheduler + Sized
+{
     if ports.len() > 1 {
         panic!("Currently this pipeline cannot handle more than one port per pipeline");
     }
     println!("Sending started");
-    for port in &ports {
-        println!("Sending port {} rxq {} txq {} on core {}",
-                 port.port.mac_address(),
-                 port.rxq(),
-                 port.txq(),
-                 core);
-    }
 
     let (producer, consumer) = new_mpsc_queue_pair();
-    let mut sched = StandaloneScheduler::new();
     let pipeline = consumer.send(ports[0].clone());
     let creator = PacketCreator::new(producer);
+
     sched.add_task(creator).unwrap();
     sched.add_task(pipeline).unwrap();
-    sched.execute_loop();
 }
 
 fn main() {
+    let opts = basic_opts();
+
     let args: Vec<String> = env::args().collect();
-    let program = args[0].clone();
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("", "secondary", "run as a secondary process");
-    opts.optopt("n", "name", "name to use for the current process", "name");
-    opts.optmulti("p", "port", "Port to use", "[type:]id");
-    opts.optmulti("c", "core", "Core to use", "core");
-    opts.optopt("m", "master", "Master core", "master");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
     };
-    if matches.opt_present("h") {
-        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
-        process::exit(0)
-    }
+    let configuration = read_matches(&matches, &opts);
 
-    let cores_str = matches.opt_strs("c");
-    let master_core = matches
-        .opt_str("m")
-        .unwrap_or_else(|| String::from("0"))
-        .parse()
-        .expect("Could not parse master core spec");
-    println!("Using master core {}", master_core);
-    let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
+    match initialize_system(&configuration) {
+        Ok(mut context) => {
+            context.start_schedulers();
+            context.add_pipeline_to_run(Arc::new(move |p, s: &mut StandaloneScheduler| test(p, s)));
+            context.execute();
 
-    let cores: Vec<i32> = cores_str
-        .iter()
-        .map(|n: &String| {
-                 n.parse()
-                     .ok()
-                     .expect(&format!("Core cannot be parsed {}", n))
-             })
-        .collect();
-
-
-    fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
-        let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
-        for (port, core) in ports.iter().zip(cores.iter()) {
-            cores_for_port
-                .entry(port.clone())
-                .or_insert(vec![])
-                .push(*core)
-        }
-        cores_for_port
-    }
-
-    let primary = !matches.opt_present("secondary");
-
-    let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
-
-    if primary {
-        init_system_wl(&name, master_core, &[]);
-    } else {
-        init_system_secondary(&name, master_core);
-    }
-
-    let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
-
-    let mut queues_by_core = HashMap::<i32, Vec<_>>::with_capacity(cores.len());
-    let mut ports = Vec::<Arc<PmdPort>>::with_capacity(ports_to_activate.len());
-    for port in &ports_to_activate {
-        let cores = cores_for_port.get(*port).unwrap();
-        let queues = cores.len() as i32;
-        let pmd_port = PmdPort::new_with_queues(*port, queues, queues, cores, cores)
-            .expect("Could not initialize port");
-        for (idx, core) in cores.iter().enumerate() {
-            let queue = idx as i32;
-            queues_by_core
-                .entry(*core)
-                .or_insert(vec![])
-                .push(PmdPort::new_queue_pair(&pmd_port, queue, queue).unwrap());
-        }
-        ports.push(pmd_port);
-    }
-
-    let pkt = new_packet().unwrap();
-    let pkt_mbuf = unsafe { pkt.get_mbuf() };
-    let pkt = unsafe { packet_from_mbuf::<NullHeader>(pkt_mbuf, 0) };
-    drop(pkt);
-
-    let _thread: Vec<_> = queues_by_core
-        .iter()
-        .map(|(core, ports)| {
-                 let c = core.clone();
-                 let p: Vec<_> = ports.iter().map(|p| p.clone()).collect();
-                 std::thread::spawn(move || recv_thread(p, c))
-             })
-        .collect();
-    let mut pkts_so_far = (0, 0);
-    let mut last_printed = 0.;
-    const MAX_PRINT_INTERVAL: f64 = 30.;
-    const PRINT_DELAY: f64 = 15.;
-    let sleep_delay = (PRINT_DELAY / 2.) as u64;
-    let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-    let sleep_time = Duration::from_millis(sleep_delay);
-    println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
-    loop {
-        thread::sleep(sleep_time); // Sleep for a bit
-        let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-        if now - start > PRINT_DELAY {
-            let mut rx = 0;
-            let mut tx = 0;
-            for port in &ports {
-                for q in 0..port.rxqs() {
-                    let (rp, tp) = port.stats(q);
-                    rx += rp;
-                    tx += tp;
+            let mut pkts_so_far = (0, 0);
+            let mut last_printed = 0.;
+            const MAX_PRINT_INTERVAL: f64 = 30.;
+            const PRINT_DELAY: f64 = 15.;
+            let sleep_delay = (PRINT_DELAY / 2.) as u64;
+            let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+            let sleep_time = Duration::from_millis(sleep_delay);
+            println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
+            loop {
+                thread::sleep(sleep_time); // Sleep for a bit
+                let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+                if now - start > PRINT_DELAY {
+                    let mut rx = 0;
+                    let mut tx = 0;
+                    for port in context.ports.values() {
+                        for q in 0..port.rxqs() {
+                            let (rp, tp) = port.stats(q);
+                            rx += rp;
+                            tx += tp;
+                        }
+                    }
+                    let pkts = (rx, tx);
+                    let rx_pkts = pkts.0 - pkts_so_far.0;
+                    if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
+                        println!("{:.2} OVERALL RX {:.2} TX {:.2}",
+                                 now - start,
+                                 rx_pkts as f64 / (now - start),
+                                 (pkts.1 - pkts_so_far.1) as f64 / (now - start));
+                        last_printed = now;
+                        start = now;
+                        pkts_so_far = pkts;
+                    }
                 }
             }
-            let pkts = (rx, tx);
-            let rx_pkts = pkts.0 - pkts_so_far.0;
-            if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
-                println!("{:.2} OVERALL RX {:.2} TX {:.2}",
-                         now - start,
-                         rx_pkts as f64 / (now - start),
-                         (pkts.1 - pkts_so_far.1) as f64 / (now - start));
-                last_printed = now;
-                start = now;
-                pkts_so_far = pkts;
+        }
+        Err(ref e) => {
+            println!("Error: {}", e);
+            if let Some(backtrace) = e.backtrace() {
+                println!("Backtrace: {:?}", backtrace);
             }
+            process::exit(1);
         }
     }
 }

--- a/test/packet_test/src/main.rs
+++ b/test/packet_test/src/main.rs
@@ -6,14 +6,12 @@ extern crate time;
 extern crate getopts;
 extern crate rand;
 use self::nf::*;
-use e2d2::allocators::CacheAligned;
+use e2d2::config::{basic_opts, read_matches};
 use e2d2::interface::*;
-use e2d2::interface::dpdk::*;
 use e2d2::operators::*;
 use e2d2::scheduler::*;
-use getopts::Options;
-use std::collections::HashMap;
 use std::env;
+use std::fmt::Display;
 use std::process;
 use std::sync::Arc;
 use std::thread;
@@ -22,149 +20,79 @@ mod nf;
 
 const CONVERSION_FACTOR: f64 = 1000000000.;
 
-fn recv_thread(ports: Vec<CacheAligned<PortQueue>>, core: i32) {
-    init_thread(core, core);
+fn test<T, S>(ports: Vec<T>, sched: &mut S)
+    where T: PacketRx + PacketTx + Display + Clone + 'static,
+          S: Scheduler + Sized
+{
     println!("Receiving started");
-    for port in &ports {
-        println!("Receiving port {} rxq {} txq {} on core {}",
-                 port.port.mac_address(),
-                 port.rxq(),
-                 port.txq(),
-                 core);
-    }
 
     let pipelines: Vec<_> = ports
         .iter()
         .map(|port| delay(ReceiveBatch::new(port.clone())).send(port.clone()))
         .collect();
     println!("Running {} pipelines", pipelines.len());
-    let mut sched = StandaloneScheduler::new();
     for pipeline in pipelines {
         sched.add_task(pipeline).unwrap();
     }
-    sched.execute_loop();
 }
 
 fn main() {
+    let opts = basic_opts();
+
     let args: Vec<String> = env::args().collect();
-    let program = args[0].clone();
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("", "secondary", "run as a secondary process");
-    opts.optopt("n", "name", "name to use for the current process", "name");
-    opts.optmulti("p", "port", "Port to use", "[type:]id");
-    opts.optmulti("c", "core", "Core to use", "core");
-    opts.optopt("m", "master", "Master core", "master");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
     };
-    if matches.opt_present("h") {
-        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
-        process::exit(0)
-    }
+    let configuration = read_matches(&matches, &opts);
 
-    let cores_str = matches.opt_strs("c");
-    let master_core = matches
-        .opt_str("m")
-        .unwrap_or_else(|| String::from("0"))
-        .parse()
-        .expect("Could not parse master core spec");
-    println!("Using master core {}", master_core);
-    let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
+    match initialize_system(&configuration) {
+        Ok(mut context) => {
+            context.start_schedulers();
+            context.add_pipeline_to_run(Arc::new(move |p, s: &mut StandaloneScheduler| test(p, s)));
+            context.execute();
 
-    let cores: Vec<i32> = cores_str
-        .iter()
-        .map(|n: &String| {
-                 n.parse()
-                     .ok()
-                     .expect(&format!("Core cannot be parsed {}", n))
-             })
-        .collect();
-
-
-    fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
-        let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
-        for (port, core) in ports.iter().zip(cores.iter()) {
-            cores_for_port
-                .entry(port.clone())
-                .or_insert(vec![])
-                .push(*core)
-        }
-        cores_for_port
-    }
-
-    let primary = !matches.opt_present("secondary");
-
-    let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
-
-    if primary {
-        init_system_wl(&name, master_core, &[]);
-    } else {
-        init_system_secondary(&name, master_core);
-    }
-
-    let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
-
-    let mut queues_by_core = HashMap::<i32, Vec<_>>::with_capacity(cores.len());
-    let mut ports = Vec::<Arc<PmdPort>>::with_capacity(ports_to_activate.len());
-    for port in &ports_to_activate {
-        let cores = cores_for_port.get(*port).unwrap();
-        let queues = cores.len() as i32;
-        let pmd_port = PmdPort::new_with_queues(*port, queues, queues, cores, cores)
-            .expect("Could not initialize port");
-        for (idx, core) in cores.iter().enumerate() {
-            let queue = idx as i32;
-            queues_by_core
-                .entry(*core)
-                .or_insert(vec![])
-                .push(PmdPort::new_queue_pair(&pmd_port, queue, queue).unwrap());
-        }
-        ports.push(pmd_port);
-    }
-
-    const _BATCH: usize = 1 << 10;
-    const _CHANNEL_SIZE: usize = 256;
-    let _thread: Vec<_> = queues_by_core
-        .iter()
-        .map(|(core, ports)| {
-                 let c = core.clone();
-                 let p: Vec<_> = ports.iter().map(|p| p.clone()).collect();
-                 std::thread::spawn(move || recv_thread(p, c))
-             })
-        .collect();
-    let mut pkts_so_far = (0, 0);
-    let mut last_printed = 0.;
-    const MAX_PRINT_INTERVAL: f64 = 30.;
-    const PRINT_DELAY: f64 = 15.;
-    let sleep_delay = (PRINT_DELAY / 2.) as u64;
-    let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-    let sleep_time = Duration::from_millis(sleep_delay);
-    println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
-    loop {
-        thread::sleep(sleep_time); // Sleep for a bit
-        let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-        if now - start > PRINT_DELAY {
-            let mut rx = 0;
-            let mut tx = 0;
-            for port in &ports {
-                for q in 0..port.rxqs() {
-                    let (rp, tp) = port.stats(q);
-                    rx += rp;
-                    tx += tp;
+            let mut pkts_so_far = (0, 0);
+            let mut last_printed = 0.;
+            const MAX_PRINT_INTERVAL: f64 = 30.;
+            const PRINT_DELAY: f64 = 15.;
+            let sleep_delay = (PRINT_DELAY / 2.) as u64;
+            let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+            let sleep_time = Duration::from_millis(sleep_delay);
+            println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
+            loop {
+                thread::sleep(sleep_time); // Sleep for a bit
+                let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+                if now - start > PRINT_DELAY {
+                    let mut rx = 0;
+                    let mut tx = 0;
+                    for port in context.ports.values() {
+                        for q in 0..port.rxqs() {
+                            let (rp, tp) = port.stats(q);
+                            rx += rp;
+                            tx += tp;
+                        }
+                    }
+                    let pkts = (rx, tx);
+                    let rx_pkts = pkts.0 - pkts_so_far.0;
+                    if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
+                        println!("{:.2} OVERALL RX {:.2} TX {:.2}",
+                                 now - start,
+                                 rx_pkts as f64 / (now - start),
+                                 (pkts.1 - pkts_so_far.1) as f64 / (now - start));
+                        last_printed = now;
+                        start = now;
+                        pkts_so_far = pkts;
+                    }
                 }
             }
-            let pkts = (rx, tx);
-            let rx_pkts = pkts.0 - pkts_so_far.0;
-            if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
-                println!("{:.2} OVERALL RX {:.2} TX {:.2}",
-                         now - start,
-                         rx_pkts as f64 / (now - start),
-                         (pkts.1 - pkts_so_far.1) as f64 / (now - start));
-                last_printed = now;
-                start = now;
-                pkts_so_far = pkts;
+        }
+        Err(ref e) => {
+            println!("Error: {}", e);
+            if let Some(backtrace) = e.backtrace() {
+                println!("Backtrace: {:?}", backtrace);
             }
+            process::exit(1);
         }
     }
 }

--- a/test/reset-parse/src/main.rs
+++ b/test/reset-parse/src/main.rs
@@ -6,211 +6,100 @@ extern crate time;
 extern crate getopts;
 extern crate rand;
 use self::nf::*;
-use e2d2::allocators::CacheAligned;
-use e2d2::config::*;
+use e2d2::config::{basic_opts, read_matches};
 use e2d2::interface::*;
-use e2d2::interface::dpdk::*;
 use e2d2::operators::*;
 use e2d2::scheduler::*;
-use getopts::Options;
-use std::collections::HashMap;
 use std::env;
-use std::error::Error;
+use std::fmt::Display;
 use std::process;
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 mod nf;
 
 const CONVERSION_FACTOR: f64 = 1000000000.;
 
-fn recv_thread(ports: Vec<CacheAligned<PortQueue>>, core: i32, delay_arg: u64) {
-    init_thread(core, core);
+fn test<T, S>(ports: Vec<T>, sched: &mut S, delay_arg: u64)
+    where T: PacketRx + PacketTx + Display + Clone + 'static,
+          S: Scheduler + Sized
+{
     println!("Receiving started");
-    for port in &ports {
-        println!("Receiving port {} rxq {} txq {} on core {} delay {}",
-                 port.port.mac_address(),
-                 port.rxq(),
-                 port.txq(),
-                 core,
-                 delay_arg);
-    }
 
     let pipelines: Vec<_> = ports
         .iter()
         .map(|port| delay(ReceiveBatch::new(port.clone()), delay_arg).send(port.clone()))
         .collect();
     println!("Running {} pipelines", pipelines.len());
-    let mut sched = StandaloneScheduler::new();
     for pipeline in pipelines {
         sched.add_task(pipeline).unwrap();
     }
-    sched.execute_loop();
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    let program = args[0].clone();
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("", "secondary", "run as a secondary process");
-    opts.optflag("", "primary", "run as a primary process");
-    opts.optopt("n", "name", "name to use for the current process", "name");
-    opts.optmulti("p", "port", "Port to use", "[type:]id");
-    opts.optmulti("c", "core", "Core to use", "core");
-    opts.optopt("m", "master", "Master core", "master");
+    let mut opts = basic_opts();
     opts.optopt("d", "delay", "Delay cycles", "cycles");
-    opts.optopt("f", "configuration", "Configuration file", "path");
+
+    let args: Vec<String> = env::args().collect();
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
     };
-    if matches.opt_present("h") {
-        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
-        process::exit(0)
-    }
 
+    let configuration = read_matches(&matches, &opts);
     let delay_arg = matches
         .opt_str("d")
         .unwrap_or_else(|| String::from("100"))
         .parse()
         .expect("Could not parse delay");
 
-    let configuration = if matches.opt_present("f") {
-        let config_file = matches.opt_str("f").unwrap();
-        match read_configuration(&config_file[..]) {
-            Ok(cfg) => cfg,
-            Err(e) => {
-                panic!("Could not parse configuration file {}\n {}",
-                       config_file,
-                       e.description())
-            }
-        }
-    } else {
-        let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
-        NetbricksConfiguration::new_with_name(&name[..])
-    };
+    match initialize_system(&configuration) {
+        Ok(mut context) => {
+            context.start_schedulers();
+            context.add_pipeline_to_run(Arc::new(move |p, s: &mut StandaloneScheduler| test(p, s, delay_arg)));
+            context.execute();
 
-    let configuration = if matches.opt_present("m") {
-        NetbricksConfiguration {
-            primary_core: matches
-                .opt_str("m")
-                .unwrap()
-                .parse()
-                .expect("Could not parse master core"),
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    let configuration = if matches.opt_present("secondary") {
-        NetbricksConfiguration {
-            secondary: true,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    let configuration = if matches.opt_present("primary") {
-        NetbricksConfiguration {
-            secondary: false,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
-        let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
-        for (port, core) in ports.iter().zip(cores.iter()) {
-            cores_for_port
-                .entry(port.clone())
-                .or_insert(vec![])
-                .push(*core)
-        }
-        cores_for_port
-    }
-
-    let configuration = if matches.opt_present("c") {
-
-        let cores_str = matches.opt_strs("c");
-
-        let cores: Vec<i32> = cores_str
-            .iter()
-            .map(|n: &String| {
-                     n.parse()
-                         .ok()
-                         .expect(&format!("Core cannot be parsed {}", n))
-                 })
-            .collect();
-
-
-        let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
-
-        let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
-
-        let mut ports = Vec::with_capacity(ports_to_activate.len());
-
-        for port in &ports_to_activate {
-            let cores = cores_for_port.get(*port).unwrap();
-            ports.push(PortConfiguration::new_with_queues(*port, cores, cores))
-        }
-        NetbricksConfiguration {
-            ports: ports,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    println!("Going to start with configuration {}", configuration);
-
-    let config = initialize_system(&configuration).unwrap();
-
-    const _BATCH: usize = 1 << 10;
-    const _CHANNEL_SIZE: usize = 256;
-    let _thread: Vec<_> = config
-        .rx_queues
-        .iter()
-        .map(|(core, ports)| {
-                 let c = core.clone();
-                 let p: Vec<_> = ports.iter().map(|p| p.clone()).collect();
-                 std::thread::spawn(move || recv_thread(p, c, delay_arg))
-             })
-        .collect();
-    let mut pkts_so_far = (0, 0);
-    let mut last_printed = 0.;
-    const MAX_PRINT_INTERVAL: f64 = 30.;
-    const PRINT_DELAY: f64 = 15.;
-    let sleep_delay = (PRINT_DELAY / 2.) as u64;
-    let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-    let sleep_time = Duration::from_millis(sleep_delay);
-    println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
-    loop {
-        thread::sleep(sleep_time); // Sleep for a bit
-        let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-        if now - start > PRINT_DELAY {
-            let mut rx = 0;
-            let mut tx = 0;
-            for port in config.ports.values() {
-                for q in 0..port.rxqs() {
-                    let (rp, tp) = port.stats(q);
-                    rx += rp;
-                    tx += tp;
+            let mut pkts_so_far = (0, 0);
+            let mut last_printed = 0.;
+            const MAX_PRINT_INTERVAL: f64 = 30.;
+            const PRINT_DELAY: f64 = 15.;
+            let sleep_delay = (PRINT_DELAY / 2.) as u64;
+            let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+            let sleep_time = Duration::from_millis(sleep_delay);
+            println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
+            loop {
+                thread::sleep(sleep_time); // Sleep for a bit
+                let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+                if now - start > PRINT_DELAY {
+                    let mut rx = 0;
+                    let mut tx = 0;
+                    for port in context.ports.values() {
+                        for q in 0..port.rxqs() {
+                            let (rp, tp) = port.stats(q);
+                            rx += rp;
+                            tx += tp;
+                        }
+                    }
+                    let pkts = (rx, tx);
+                    let rx_pkts = pkts.0 - pkts_so_far.0;
+                    if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
+                        println!("{:.2} OVERALL RX {:.2} TX {:.2}",
+                                 now - start,
+                                 rx_pkts as f64 / (now - start),
+                                 (pkts.1 - pkts_so_far.1) as f64 / (now - start));
+                        last_printed = now;
+                        start = now;
+                        pkts_so_far = pkts;
+                    }
                 }
             }
-            let pkts = (rx, tx);
-            let rx_pkts = pkts.0 - pkts_so_far.0;
-            if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
-                println!("{:.2} OVERALL RX {:.2} TX {:.2}",
-                         now - start,
-                         rx_pkts as f64 / (now - start),
-                         (pkts.1 - pkts_so_far.1) as f64 / (now - start));
-                last_printed = now;
-                start = now;
-                pkts_so_far = pkts;
+        }
+        Err(ref e) => {
+            println!("Error: {}", e);
+            if let Some(backtrace) = e.backtrace() {
+                println!("Backtrace: {:?}", backtrace);
             }
+            process::exit(1);
         }
     }
 }

--- a/test/sctp-test/src/main.rs
+++ b/test/sctp-test/src/main.rs
@@ -9,15 +9,13 @@ extern crate nix;
 extern crate sctp;
 use self::control::*;
 use self::nf::*;
-use e2d2::allocators::CacheAligned;
+use e2d2::config::{basic_opts, read_matches};
 use e2d2::control::sctp::*;
 use e2d2::interface::*;
-use e2d2::interface::dpdk::*;
 use e2d2::operators::*;
 use e2d2::scheduler::*;
-use getopts::Options;
-use std::collections::HashMap;
 use std::env;
+use std::fmt::Display;
 use std::net::*;
 use std::process;
 use std::str::FromStr;
@@ -29,160 +27,88 @@ mod control;
 
 const CONVERSION_FACTOR: f64 = 1000000000.;
 
-fn recv_thread(ports: Vec<CacheAligned<PortQueue>>, core: i32, delay_arg: u64) {
-    init_thread(core, core);
+fn test<T, S>(ports: Vec<T>, sched: &mut S, delay_arg: u64)
+    where T: PacketRx + PacketTx + Display + Clone + 'static,
+          S: Scheduler + Sized
+{
     println!("Receiving started");
-    for port in &ports {
-        println!("Receiving port {} rxq {} txq {} on core {} delay {}",
-                 port.port.mac_address(),
-                 port.rxq(),
-                 port.txq(),
-                 core,
-                 delay_arg);
-    }
 
     let pipelines: Vec<_> = ports
         .iter()
         .map(|port| delay(ReceiveBatch::new(port.clone()), delay_arg).send(port.clone()))
         .collect();
     println!("Running {} pipelines", pipelines.len());
-    let mut sched = StandaloneScheduler::new();
     for pipeline in pipelines {
         sched.add_task(pipeline).unwrap();
     }
     let addr = SocketAddrV4::new(Ipv4Addr::from_str("0.0.0.0").unwrap(), 8001);
     let control = SctpControlServer::<ControlListener>::new_streaming(SocketAddr::V4(addr));
     sched.add_task(control).unwrap();
-    sched.execute_loop();
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    let program = args[0].clone();
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("", "secondary", "run as a secondary process");
-    opts.optopt("n", "name", "name to use for the current process", "name");
-    opts.optmulti("p", "port", "Port to use", "[type:]id");
-    opts.optmulti("c", "core", "Core to use", "core");
-    opts.optopt("m", "master", "Master core", "master");
+    let mut opts = basic_opts();
     opts.optopt("d", "delay", "Delay cycles", "cycles");
+
+    let args: Vec<String> = env::args().collect();
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
     };
-    if matches.opt_present("h") {
-        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
-        process::exit(0)
-    }
-
+    let configuration = read_matches(&matches, &opts);
     let delay_arg = matches
         .opt_str("d")
         .unwrap_or_else(|| String::from("100"))
         .parse()
         .expect("Could not parse delay");
 
-    let cores_str = matches.opt_strs("c");
-    let master_core = matches
-        .opt_str("m")
-        .unwrap_or_else(|| String::from("0"))
-        .parse()
-        .expect("Could not parse master core spec");
-    println!("Using master core {}", master_core);
-    let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
+    match initialize_system(&configuration) {
+        Ok(mut context) => {
+            context.start_schedulers();
+            context.add_pipeline_to_run(Arc::new(move |p, s: &mut StandaloneScheduler| test(p, s, delay_arg)));
+            context.execute();
 
-    let cores: Vec<i32> = cores_str
-        .iter()
-        .map(|n: &String| {
-                 n.parse()
-                     .ok()
-                     .expect(&format!("Core cannot be parsed {}", n))
-             })
-        .collect();
-
-
-    fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
-        let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
-        for (port, core) in ports.iter().zip(cores.iter()) {
-            cores_for_port
-                .entry(port.clone())
-                .or_insert(vec![])
-                .push(*core)
-        }
-        cores_for_port
-    }
-
-    let primary = !matches.opt_present("secondary");
-
-    let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
-
-    if primary {
-        init_system_wl(&name, master_core, &[]);
-    } else {
-        init_system_secondary(&name, master_core);
-    }
-
-    let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
-
-    let mut queues_by_core = HashMap::<i32, Vec<_>>::with_capacity(cores.len());
-    let mut ports = Vec::<Arc<PmdPort>>::with_capacity(ports_to_activate.len());
-    for port in &ports_to_activate {
-        let cores = cores_for_port.get(*port).unwrap();
-        let queues = cores.len() as i32;
-        let pmd_port = PmdPort::new_with_queues(*port, queues, queues, cores, cores)
-            .expect("Could not initialize port");
-        for (idx, core) in cores.iter().enumerate() {
-            let queue = idx as i32;
-            queues_by_core
-                .entry(*core)
-                .or_insert(vec![])
-                .push(PmdPort::new_queue_pair(&pmd_port, queue, queue).unwrap());
-        }
-        ports.push(pmd_port);
-    }
-
-    const _BATCH: usize = 1 << 10;
-    const _CHANNEL_SIZE: usize = 256;
-    let _thread: Vec<_> = queues_by_core
-        .iter()
-        .map(|(core, ports)| {
-                 let c = core.clone();
-                 let p: Vec<_> = ports.iter().map(|p| p.clone()).collect();
-                 std::thread::spawn(move || recv_thread(p, c, delay_arg))
-             })
-        .collect();
-    let mut pkts_so_far = (0, 0);
-    let mut last_printed = 0.;
-    const MAX_PRINT_INTERVAL: f64 = 30.;
-    const PRINT_DELAY: f64 = 15.;
-    let sleep_delay = (PRINT_DELAY / 2.) as u64;
-    let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-    let sleep_time = Duration::from_millis(sleep_delay);
-    println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
-    loop {
-        thread::sleep(sleep_time); // Sleep for a bit
-        let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-        if now - start > PRINT_DELAY {
-            let mut rx = 0;
-            let mut tx = 0;
-            for port in &ports {
-                for q in 0..port.rxqs() {
-                    let (rp, tp) = port.stats(q);
-                    rx += rp;
-                    tx += tp;
+            let mut pkts_so_far = (0, 0);
+            let mut last_printed = 0.;
+            const MAX_PRINT_INTERVAL: f64 = 30.;
+            const PRINT_DELAY: f64 = 15.;
+            let sleep_delay = (PRINT_DELAY / 2.) as u64;
+            let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+            let sleep_time = Duration::from_millis(sleep_delay);
+            println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
+            loop {
+                thread::sleep(sleep_time); // Sleep for a bit
+                let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+                if now - start > PRINT_DELAY {
+                    let mut rx = 0;
+                    let mut tx = 0;
+                    for port in context.ports.values() {
+                        for q in 0..port.rxqs() {
+                            let (rp, tp) = port.stats(q);
+                            rx += rp;
+                            tx += tp;
+                        }
+                    }
+                    let pkts = (rx, tx);
+                    let rx_pkts = pkts.0 - pkts_so_far.0;
+                    if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
+                        println!("{:.2} OVERALL RX {:.2} TX {:.2}",
+                                 now - start,
+                                 rx_pkts as f64 / (now - start),
+                                 (pkts.1 - pkts_so_far.1) as f64 / (now - start));
+                        last_printed = now;
+                        start = now;
+                        pkts_so_far = pkts;
+                    }
                 }
             }
-            let pkts = (rx, tx);
-            let rx_pkts = pkts.0 - pkts_so_far.0;
-            if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
-                println!("{:.2} OVERALL RX {:.2} TX {:.2}",
-                         now - start,
-                         rx_pkts as f64 / (now - start),
-                         (pkts.1 - pkts_so_far.1) as f64 / (now - start));
-                last_printed = now;
-                start = now;
-                pkts_so_far = pkts;
+        }
+        Err(ref e) => {
+            println!("Error: {}", e);
+            if let Some(backtrace) = e.backtrace() {
+                println!("Backtrace: {:?}", backtrace);
             }
+            process::exit(1);
         }
     }
 }

--- a/test/shutdown-test/src/main.rs
+++ b/test/shutdown-test/src/main.rs
@@ -7,13 +7,10 @@ extern crate getopts;
 extern crate rand;
 use self::nf::*;
 use e2d2::allocators::CacheAligned;
-use e2d2::common::*;
 use e2d2::config::*;
 use e2d2::interface::*;
 use e2d2::operators::*;
 use e2d2::scheduler::*;
-use getopts::Options;
-use std::collections::HashMap;
 use std::env;
 use std::process;
 use std::sync::Arc;
@@ -43,26 +40,15 @@ fn test<S: Scheduler + Sized>(ports: Vec<CacheAligned<PortQueue>>, sched: &mut S
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    let program = args[0].clone();
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("", "secondary", "run as a secondary process");
-    opts.optflag("", "primary", "run as a primary process");
-    opts.optopt("n", "name", "name to use for the current process", "name");
-    opts.optmulti("p", "port", "Port to use", "[type:]id");
-    opts.optmulti("c", "core", "Core to use", "core");
-    opts.optopt("m", "master", "Master core", "master");
+    let mut opts = basic_opts();
     opts.optopt("d", "delay", "Delay cycles", "cycles");
-    opts.optopt("f", "configuration", "Configuration file", "path");
+
+    let args: Vec<String> = env::args().collect();
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
     };
-    if matches.opt_present("h") {
-        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
-        process::exit(0)
-    }
+    let configuration = read_matches(&matches, &opts);
 
     let delay_arg = matches
         .opt_str("d")
@@ -70,100 +56,6 @@ fn main() {
         .parse()
         .expect("Could not parse delay");
 
-    let configuration = if matches.opt_present("f") {
-        let config_file = matches.opt_str("f").unwrap();
-        match read_configuration(&config_file[..]) {
-            Ok(cfg) => cfg,
-            Err(ref e) => {
-                print_error(e);
-                process::exit(1);
-            }
-        }
-    } else {
-        let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
-        NetbricksConfiguration::new_with_name(&name[..])
-    };
-
-    let configuration = if matches.opt_present("m") {
-        NetbricksConfiguration {
-            primary_core: matches
-                .opt_str("m")
-                .unwrap()
-                .parse()
-                .expect("Could not parse master core"),
-            strict: true,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    let configuration = if matches.opt_present("secondary") {
-        NetbricksConfiguration {
-            secondary: true,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    let configuration = if matches.opt_present("primary") {
-        NetbricksConfiguration {
-            secondary: false,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
-        let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
-        for (port, core) in ports.iter().zip(cores.iter()) {
-            cores_for_port
-                .entry(port.clone())
-                .or_insert(vec![])
-                .push(*core)
-        }
-        cores_for_port
-    }
-
-    let configuration = if matches.opt_present("c") {
-
-        let cores_str = matches.opt_strs("c");
-
-        let mut cores: Vec<i32> = cores_str
-            .iter()
-            .map(|n: &String| {
-                     n.parse()
-                         .ok()
-                         .expect(&format!("Core cannot be parsed {}", n))
-                 })
-            .collect();
-
-
-        let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
-
-        let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
-
-        let mut ports = Vec::with_capacity(ports_to_activate.len());
-
-        for port in &ports_to_activate {
-            let cores = cores_for_port.get(*port).unwrap();
-            ports.push(PortConfiguration::new_with_queues(*port, cores, cores))
-        }
-        cores.dedup();
-        NetbricksConfiguration {
-            cores: cores,
-            ports: ports,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    println!("Going to start with configuration {}", configuration);
-
-    // let mut config = initialize_system(&configuration)
     match initialize_system(&configuration) {
         Ok(mut context) => {
             context.start_schedulers();

--- a/test/tcp_check/src/main.rs
+++ b/test/tcp_check/src/main.rs
@@ -5,166 +5,93 @@ extern crate time;
 extern crate getopts;
 extern crate rand;
 use self::nf::*;
-use e2d2::allocators::CacheAligned;
+use e2d2::config::{basic_opts, read_matches};
 use e2d2::interface::*;
-use e2d2::interface::dpdk::*;
 use e2d2::operators::*;
 use e2d2::scheduler::*;
-use getopts::Options;
-use std::collections::HashMap;
 use std::env;
+use std::fmt::Display;
 use std::process;
 use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 mod nf;
 
-fn recv_thread(ports: Vec<CacheAligned<PortQueue>>, core: i32) {
-    init_thread(core, core);
+const CONVERSION_FACTOR: f64 = 1000000000.;
+
+fn test<T, S>(ports: Vec<T>, sched: &mut S)
+    where T: PacketRx + PacketTx + Display + Clone + 'static,
+          S: Scheduler + Sized
+{
     println!("Receiving started");
-    for port in &ports {
-        println!("Receiving port {} rxq {} txq {} on core {}",
-                 port.port.mac_address(),
-                 port.rxq(),
-                 port.txq(),
-                 core);
-    }
 
     let pipelines: Vec<_> = ports
         .iter()
         .map(|port| tcp_nf(ReceiveBatch::new(port.clone())).send(port.clone()))
         .collect();
     println!("Running {} pipelines", pipelines.len());
-    let mut sched = StandaloneScheduler::new();
     for pipeline in pipelines {
         sched.add_task(pipeline).unwrap();
     }
-    sched.execute_one();
 }
 
 fn main() {
+    let opts = basic_opts();
     let args: Vec<String> = env::args().collect();
-    let program = args[0].clone();
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("", "secondary", "run as a secondary process");
-    opts.optopt("n", "name", "name to use for the current process", "name");
-    opts.optmulti("p", "port", "Port to use", "[type:]id");
-    opts.optmulti("c", "core", "Core to use", "core");
-    opts.optopt("m", "master", "Master core", "master");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
     };
-    if matches.opt_present("h") {
-        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
-        process::exit(0)
-    }
 
-    let cores_str = matches.opt_strs("c");
-    let master_core = matches
-        .opt_str("m")
-        .unwrap_or_else(|| String::from("0"))
-        .parse()
-        .expect("Could not parse master core spec");
-    println!("Using master core {}", master_core);
-    let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
+    let configuration = read_matches(&matches, &opts);
 
-    let cores: Vec<i32> = cores_str
-        .iter()
-        .map(|n: &String| {
-                 n.parse()
-                     .ok()
-                     .expect(&format!("Core cannot be parsed {}", n))
-             })
-        .collect();
+    match initialize_system(&configuration) {
+        Ok(mut context) => {
+            context.start_schedulers();
+            context.add_pipeline_to_run(Arc::new(move |p, s: &mut StandaloneScheduler| test(p, s)));
+            context.execute();
 
-
-    fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
-        let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
-        for (port, core) in ports.iter().zip(cores.iter()) {
-            cores_for_port
-                .entry(port.clone())
-                .or_insert(vec![])
-                .push(*core)
+            let mut pkts_so_far = (0, 0);
+            let mut last_printed = 0.;
+            const MAX_PRINT_INTERVAL: f64 = 120.;
+            const PRINT_DELAY: f64 = 60.;
+            let sleep_delay = (PRINT_DELAY / 2.) as u64;
+            let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+            let sleep_time = Duration::from_millis(sleep_delay);
+            println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
+            loop {
+                thread::sleep(sleep_time); // Sleep for a bit
+                let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
+                if now - start > PRINT_DELAY {
+                    let mut rx = 0;
+                    let mut tx = 0;
+                    for port in context.ports.values() {
+                        for q in 0..port.rxqs() {
+                            let (rp, tp) = port.stats(q);
+                            rx += rp;
+                            tx += tp;
+                        }
+                    }
+                    let pkts = (rx, tx);
+                    let rx_pkts = pkts.0 - pkts_so_far.0;
+                    if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
+                        println!("{:.2} OVERALL RX {:.2} TX {:.2}",
+                                 now - start,
+                                 rx_pkts as f64 / (now - start),
+                                 (pkts.1 - pkts_so_far.1) as f64 / (now - start));
+                        last_printed = now;
+                        start = now;
+                        pkts_so_far = pkts;
+                    }
+                }
+            }
         }
-        cores_for_port
-    }
-
-    let primary = !matches.opt_present("secondary");
-
-    let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
-
-    if primary {
-        init_system_wl(&name, master_core, &[]);
-    } else {
-        init_system_secondary(&name, master_core);
-    }
-
-    let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
-
-    let mut queues_by_core = HashMap::<i32, Vec<_>>::with_capacity(cores.len());
-    let mut ports = Vec::<Arc<PmdPort>>::with_capacity(ports_to_activate.len());
-    for port in &ports_to_activate {
-        let cores = cores_for_port.get(*port).unwrap();
-        let queues = cores.len() as i32;
-        let pmd_port = PmdPort::new_with_queues(*port, queues, queues, cores, cores)
-            .expect("Could not initialize port");
-        for (idx, core) in cores.iter().enumerate() {
-            let queue = idx as i32;
-            queues_by_core
-                .entry(*core)
-                .or_insert(vec![])
-                .push(PmdPort::new_queue_pair(&pmd_port, queue, queue).unwrap());
+        Err(ref e) => {
+            println!("Error: {}", e);
+            if let Some(backtrace) = e.backtrace() {
+                println!("Backtrace: {:?}", backtrace);
+            }
+            process::exit(1);
         }
-        ports.push(pmd_port);
     }
-
-
-    const _BATCH: usize = 1 << 10;
-    const _CHANNEL_SIZE: usize = 256;
-    let mut threads: Vec<_> = queues_by_core
-        .iter()
-        .map(|(core, ports)| {
-                 let c = core.clone();
-                 let p: Vec<_> = ports.iter().map(|p| p.clone()).collect();
-                 std::thread::spawn(move || recv_thread(p, c))
-             })
-        .collect();
-    while !threads.is_empty() {
-        let thr = threads.pop().unwrap();
-        let _ = thr.join().unwrap();
-    }
-    // let mut pkts_so_far = (0, 0);
-    // let mut last_printed = 0.;
-    // const MAX_PRINT_INTERVAL: f64 = 1.0;
-    // const PRINT_DELAY: f64 = 0.5;
-    // let sleep_delay = (PRINT_DELAY / 2.) as u64;
-    // let mut start = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-    // let sleep_time = Duration::from_millis(sleep_delay);
-    // println!("0 OVERALL RX 0.00 TX 0.00 CYCLE_PER_DELAY 0 0 0");
-    // loop {
-    // thread::sleep(sleep_time); // Sleep for a bit
-    // let now = time::precise_time_ns() as f64 / CONVERSION_FACTOR;
-    // if now - start > PRINT_DELAY {
-    // let mut rx = 0;
-    // let mut tx = 0;
-    // for port in &ports {
-    // for q in 0..port.rxqs() {
-    // let (rp, tp) = port.stats(q);
-    // rx += rp;
-    // tx += tp;
-    // }
-    // }
-    // let pkts = (rx, tx);
-    // let rx_pkts = pkts.0 - pkts_so_far.0;
-    // if rx_pkts > 0 || now - last_printed > MAX_PRINT_INTERVAL {
-    // println!("{:.2} OVERALL RX {:.2} TX {:.2}",
-    // now - start,
-    // rx_pkts as f64 / (now - start),
-    // (pkts.1 - pkts_so_far.1) as f64 / (now - start));
-    // last_printed = now;
-    // start = now;
-    // pkts_so_far = pkts;
-    // }
-    // }
-    // }
 }

--- a/test/tcp_reconstruction/src/main.rs
+++ b/test/tcp_reconstruction/src/main.rs
@@ -38,7 +38,7 @@ fn test<S: Scheduler + Sized>(ports: Vec<CacheAligned<PortQueue>>, sched: &mut S
 }
 
 fn main() {
-    let mut opts = basic_opts();
+    let opts = basic_opts();
 
     let args: Vec<String> = env::args().collect();
     let matches = match opts.parse(&args[1..]) {

--- a/test/tcp_reconstruction/src/main.rs
+++ b/test/tcp_reconstruction/src/main.rs
@@ -11,11 +11,7 @@ use e2d2::config::*;
 use e2d2::interface::*;
 use e2d2::operators::*;
 use e2d2::scheduler::*;
-use getopts::Options;
-use std::collections::HashMap;
 use std::env;
-use std::error::Error;
-use std::process;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -42,116 +38,14 @@ fn test<S: Scheduler + Sized>(ports: Vec<CacheAligned<PortQueue>>, sched: &mut S
 }
 
 fn main() {
+    let mut opts = basic_opts();
+
     let args: Vec<String> = env::args().collect();
-    let program = args[0].clone();
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("", "secondary", "run as a secondary process");
-    opts.optflag("", "primary", "run as a primary process");
-    opts.optopt("n", "name", "name to use for the current process", "name");
-    opts.optmulti("p", "port", "Port to use", "[type:]id");
-    opts.optmulti("c", "core", "Core to use", "core");
-    opts.optopt("m", "master", "Master core", "master");
-    opts.optopt("f", "configuration", "Configuration file", "path");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!(f.to_string()),
     };
-    if matches.opt_present("h") {
-        print!("{}", opts.usage(&format!("Usage: {} [options]", program)));
-        process::exit(0)
-    }
-
-    let configuration = if matches.opt_present("f") {
-        let config_file = matches.opt_str("f").unwrap();
-        match read_configuration(&config_file[..]) {
-            Ok(cfg) => cfg,
-            Err(e) => {
-                panic!("Could not parse configuration file {}\n {}",
-                       config_file,
-                       e.description())
-            }
-        }
-    } else {
-        let name = matches.opt_str("n").unwrap_or_else(|| String::from("recv"));
-        NetbricksConfiguration::new_with_name(&name[..])
-    };
-
-    let configuration = if matches.opt_present("m") {
-        NetbricksConfiguration {
-            primary_core: matches
-                .opt_str("m")
-                .unwrap()
-                .parse()
-                .expect("Could not parse master core"),
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    let configuration = if matches.opt_present("secondary") {
-        NetbricksConfiguration {
-            secondary: true,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    let configuration = if matches.opt_present("primary") {
-        NetbricksConfiguration {
-            secondary: false,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    fn extract_cores_for_port(ports: &[String], cores: &[i32]) -> HashMap<String, Vec<i32>> {
-        let mut cores_for_port = HashMap::<String, Vec<i32>>::new();
-        for (port, core) in ports.iter().zip(cores.iter()) {
-            cores_for_port
-                .entry(port.clone())
-                .or_insert(vec![])
-                .push(*core)
-        }
-        cores_for_port
-    }
-
-    let configuration = if matches.opt_present("c") {
-
-        let cores_str = matches.opt_strs("c");
-
-        let cores: Vec<i32> = cores_str
-            .iter()
-            .map(|n: &String| {
-                     n.parse()
-                         .ok()
-                         .expect(&format!("Core cannot be parsed {}", n))
-                 })
-            .collect();
-
-
-        let cores_for_port = extract_cores_for_port(&matches.opt_strs("p"), &cores);
-
-        let ports_to_activate: Vec<_> = cores_for_port.keys().collect();
-
-        let mut ports = Vec::with_capacity(ports_to_activate.len());
-
-        for port in &ports_to_activate {
-            let cores = cores_for_port.get(*port).unwrap();
-            ports.push(PortConfiguration::new_with_queues(*port, cores, cores))
-        }
-        NetbricksConfiguration {
-            ports: ports,
-            ..configuration
-        }
-    } else {
-        configuration
-    };
-
-    println!("Going to start with configuration {}", configuration);
+    let configuration = read_matches(&matches, &opts);
 
     let mut config = initialize_system(&configuration).unwrap();
     config.start_schedulers();


### PR DESCRIPTION
Move some commonly used command-line flag parsing code into
e2d2::config::flag_reader.

Refactor old code written before NetbricksConfiguration to use NetbricksConfiguration.