### PR TITLE
fix can't download llvm and libunwind.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -208,7 +208,7 @@ musl () {
 }
 
 libunwind () {
-    curl http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz \
+    curl -L http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz \
         -o "${LLVM_DOWNLOAD_PATH}"
     mkdir -p ${LLVM_RESULT}
     tar xf "${LLVM_DOWNLOAD_PATH}" \
@@ -216,7 +216,7 @@ libunwind () {
     UNWIND_DOWNLOAD="${DOWNLOAD_DIR}"/unwind.tar.gz
     UNWIND_DIR="${LLVM_RESULT}/projects/libunwind"
     mkdir -p ${UNWIND_DIR}
-    curl http://llvm.org/releases/3.7.0/libunwind-3.7.0.src.tar.xz \
+    curl -L http://llvm.org/releases/3.7.0/libunwind-3.7.0.src.tar.xz \
         -o "${UNWIND_DOWNLOAD}"
     tar xf "${UNWIND_DOWNLOAD}" -C "${UNWIND_DIR}" --strip-components=1
     mkdir -p "${UNWIND_BUILD}"


### PR DESCRIPTION
environment:
Linux version 3.13.0-116-generic (buildd@lcy01-03) (gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04.3) ) #163-Ubuntu SMP Fri Mar 31 14:13:22 UTC 2017

curl version
curl 7.35.0 (x86_64-pc-linux-gnu) libcurl/7.35.0 OpenSSL/1.0.1f zlib/1.2.8 libidn/1.28 librtmp/2.3
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smtp smtps telnet tftp 
Features: AsynchDNS GSS-Negotiate IDN IPv6 Largefile NTLM NTLM_WB SSL libz TLS-SRP 

curl http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz
curl http://llvm.org/releases/3.7.0/libunwind-3.7.0.src.tar.xz  
will download the 302 page.
 
Add '-L' to redirect the request.

or replace urls 
http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz
http://llvm.org/releases/3.7.0/libunwind-3.7.0.src.tar.xz
to
http://releases.llvm.org/3.7.0/llvm-3.7.0.src.tar.xz
http://releases.llvm.org/3.7.0/libunwind-3.7.0.src.tar.xz