### PR TITLE
Fix the build error for the latest nightly-rust

### DIFF
--- a/framework/src/allocators/cache_aligned.rs
+++ b/framework/src/allocators/cache_aligned.rs
@@ -1,4 +1,4 @@
-use std::alloc::{self, Alloc, Global, Layout, Opaque};
+use std::alloc::{self, Alloc, Global, Layout};
 use std::fmt;
 use std::mem::size_of;
 use std::ops::{Deref, DerefMut};
@@ -18,7 +18,7 @@ impl<T: Sized> Drop for CacheAligned<T> {
     fn drop(&mut self) {
         unsafe {
             alloc::Global.dealloc(
-                NonNull::<Opaque>::new_unchecked(self.ptr.as_ptr() as *mut Opaque),
+                NonNull::<u8>::new_unchecked(self.ptr.as_ptr() as *mut u8),
                 Layout::from_size_align(size_of::<T>(), CACHE_LINE_SIZE).unwrap(),
             );
         }


### PR DESCRIPTION
According to the rust-lang/rust#51241 and rust-lang/rust@f6ab74b8e7efed01c1045773b6693f23f6ebd93c, `Opaque` struct has been removed from `std::alloc`, and `u8` can be used here for the replacement.