### PR TITLE
Download link for DPDK source is '301 permanently moved'

### DIFF
--- a/3rdparty/get-dpdk.sh
+++ b/3rdparty/get-dpdk.sh
@@ -15,7 +15,7 @@ echo "Using configuration ${CONFIG_FILE}${CONFIG_PFX}"
 if [ "$MODE" = "download" ]; then
 	if [ ! -e "$DOWNLOAD_PATH" ]; then
 		echo Fetching "http://dpdk.org/browse/dpdk/snapshot/dpdk-${DPDK_VER}.tar.gz"
-		curl http://dpdk.org/browse/dpdk/snapshot/dpdk-${DPDK_VER}.tar.gz -o "${DOWNLOAD_PATH}"
+		curl http://git.dpdk.org/dpdk/snapshot/dpdk-${DPDK_VER}.tar.gz -o "${DOWNLOAD_PATH}"
 	fi
 	if [ ! -d "${DPDK_RESULT}" ]; then
 		mkdir -p ${DPDK_RESULT}


### PR DESCRIPTION
In WSL, when I tried to build NetBricks, I encoutered a following error.

```
take@DESKTOP-QC0FRNK:~/NetBricks$ ./build.sh
Using /home/take/NetBricks/3rdparty/downloads for downloads
Using configuration /home/take/NetBricks/3rdparty/dpdk-confs/common_linuxapp-17.08
Fetching http://dpdk.org/browse/dpdk/snapshot/dpdk-17.08.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   184  100   184    0     0     46      0  0:00:04  0:00:03  0:00:01    46

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

I think it is because the status code of response from http://dpdk.org/browse/dpdk/snapshot/dpdk-${DPDK_VER}.tar.gz  is "301 permanently moved".

I changed source url from http://dpdk.org/browse/dpdk/snapshot/dpdk-${DPDK_VER}.tar.gz to http://git.dpdk.org/dpdk/snapshot/dpdk-{DPDK_VER}.tar.gz. Then, I have not encountered the error above.